### PR TITLE
Terminal [FEAT & FIX] JwtExceptionFilter 추가 & JWT 인증 방식 수정

### DIFF
--- a/src/main/java/com/umbrella/security/SecurityConfig.java
+++ b/src/main/java/com/umbrella/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.umbrella.domain.User.UserRepository;
 import com.umbrella.security.login.cookie.CookieOAuth2AuthorizationRequestRepository;
 import com.umbrella.security.login.filter.JsonEmailPasswordAuthenticationFilter;
 import com.umbrella.security.login.filter.JwtAuthenticationProcessingFilter;
+import com.umbrella.security.login.filter.JwtExceptionFilter;
 import com.umbrella.security.login.handler.LoginFailureHandler;
 import com.umbrella.security.login.handler.LoginSuccessJWTProvideHandler;
 import com.umbrella.security.login.handler.OAuth2LoginFailureHandler;
@@ -65,6 +66,7 @@ public class SecurityConfig {
         .and()
                 .addFilterAfter(jsonEmailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationProcessingFilter(), JsonEmailPasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter(), JwtAuthenticationProcessingFilter.class)
                 .oauth2Login()
                     .authorizationEndpoint()
                     .authorizationRequestRepository(cookieOAuth2AuthorizationRequestRepository)
@@ -128,6 +130,11 @@ public class SecurityConfig {
                                     = new JwtAuthenticationProcessingFilter(jwtService, userRepository, roleUtil);
 
         return jwtAuthenticationProcessingFilter;
+    }
+
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter() {
+        return new JwtExceptionFilter();
     }
 
     @Bean

--- a/src/main/java/com/umbrella/security/login/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/umbrella/security/login/filter/JwtExceptionFilter.java
@@ -1,0 +1,41 @@
+package com.umbrella.security.login.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            responseJwtError(response, e.getMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            responseJwtError(response, e.getMessage());
+        }
+    }
+
+    private void responseJwtError(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(String.valueOf(MediaType.APPLICATION_JSON_VALUE));
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(message);
+    }
+}

--- a/src/main/java/com/umbrella/security/utils/RoleUtil.java
+++ b/src/main/java/com/umbrella/security/utils/RoleUtil.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 @Component
 public class RoleUtil {
-
     public Set<GrantedAuthority> addAuthoritiesForContext(User targetUser) {
         String role = targetUser.getRole().name();
 

--- a/src/main/java/com/umbrella/service/Impl/JwtServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/JwtServiceImpl.java
@@ -42,7 +42,8 @@ public class JwtServiceImpl implements JwtService {
 
 
     public JwtServiceImpl(UserRepository userRepository, @Value("${jwt.secret}") String secret,
-                          @Value("${app.auth.cookie.refresh-cookie-key}") String cookieKey, CookieUtil cookieUtil) {
+                          @Value("${app.auth.cookie.refresh-cookie-key}") String cookieKey,
+                          CookieUtil cookieUtil) {
         this.userRepository = userRepository;
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
@@ -130,8 +131,6 @@ public class JwtServiceImpl implements JwtService {
     @Override
     public void sendAccessToken(HttpServletResponse response, String accessToken) {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_OK);
-
         setAccessTokenHeader(response, accessToken);
     }
 
@@ -188,20 +187,17 @@ public class JwtServiceImpl implements JwtService {
     }
 
     @Override
-        public boolean isTokenValid(String token) {
+    public int isTokenValid(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(secretKey)
                     .build().parseClaimsJws(token);
-
-            return true;
+            return 1;
         } catch (ExpiredJwtException e) {
             log.error("만료된 토큰입니다.", e);
-
-            return false;
-        } catch (Exception e) {
+            return 0;
+        } catch (JwtException | IllegalArgumentException e) {
             log.error("유효하지 않은 토큰입니다.", e);
-
-            return false;
+            return -1;
         }
     }
 

--- a/src/main/java/com/umbrella/service/JwtService.java
+++ b/src/main/java/com/umbrella/service/JwtService.java
@@ -32,5 +32,5 @@ public interface JwtService {
     void setAccessTokenHeader(HttpServletResponse response, String accessToken);
     void setRefreshTokenHeader(HttpServletResponse response, String refreshToken);
 
-    boolean isTokenValid(String token);
+    int isTokenValid(String token);
 }

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,10 +1,10 @@
 jwt:
-  secret: { secret-key }
+  secret: 767b00f050929a4278a94287c4725dca0904661e7e0632db68552edc239d263b2f864e7cbcdaaaa73b900e82d55933f8802991d24616235e85145ea4d2713b8c
 
   access:
-    expiration: { access-expiration }
-    header: { access-header }
+    expiration: 1800 # 30분
+    header: Authorization
 
   refresh:
-    expiration: { refresh-expiration }
-    header: { refresh-header }
+    expiration: 864000 # 10일
+    header: Authorization-refresh

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -4,23 +4,23 @@ spring:
       client:
         registration:
           google:
-            client-id: { google-client-id }
-            client-secret: { google-client-secret }
-            scope: { google-scope }
+            client-id: 1034478446062-t8g2n3p6peugp65gqlknurjtk6g1hdk4.apps.googleusercontent.com
+            client-secret: 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
+            scope: profile, email
           github:
-            client-id: { github-client-id }
-            client-secret: { github-client-secret }
+            client-id: a8cf5060b620711b3a97
+            client-secret: ab999a2c007545e5b3a45365beb583a9208ab604
           naver:
-            client-id: { naver-client-id }
-            client-secret: { naver-client-secret }
-            scope: { naver-scope }
+            client-id: inPe6oE1BQjiKUYwQcmV
+            client-secret: w1Gqv13MVo
+            scope: name, email, nickname, gender, birthday, birthyear
             client-name: Naver
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           kakao:
-            client-id: { kakao-client-id }
-            client-secret: { kakao-client-secret }
-            scope: { kakao-scope }
+            client-id: 86ead32bca13a782eecf97ea7d5aab9f
+            client-secret: VUPqtpF7LjtTUkYNDdWcphZrBTLcCqkS
+            scope: profile_nickname, account_email, gender, birthday
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
@@ -40,4 +40,4 @@ spring:
 app:
   auth:
     cookie:
-      refresh-cookie-key: { refresh-cookie-key }
+      refresh-cookie-key: "refresh"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
     include: jwt, oauth2
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://{ env }/umbrella?useUnicode=true&serverTimezone=Asia/Seoul
-    username: { username }
-    password: { password }
+    url: jdbc:mysql://localhost:33060/umbrella?useUnicode=true&serverTimezone=Asia/Seoul
+    username: root
+    password: 2982
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:

--- a/src/test/java/com/umbrella/project_umbrella/controller/UserControllerTest.java
+++ b/src/test/java/com/umbrella/project_umbrella/controller/UserControllerTest.java
@@ -508,7 +508,7 @@ public class UserControllerTest {
     }
 
     @Test
-    @DisplayName("[SUCCESS]_만료된_엑세스_토큰_리프레쉬_토큰으로_갱신하고_회원정보_읽어오기")
+    @DisplayName("[FAILED]_만료된_엑세스_토큰으로_갱신하고_회원정보_읽어오기")
     public void getUserInfoTest02() throws Exception {
         // given
         String signUpData = objectMapper.writeValueAsString(createSignUpDto());
@@ -525,7 +525,7 @@ public class UserControllerTest {
                         .characterEncoding("utf-8")
                         .cookie(setRefreshTokenInCookie())
                         .header(accessHeader, BEARER + accessToken + "wrong")
-        ).andExpect(status().isOk()).andReturn() ;
+        ).andExpect(status().isForbidden()).andReturn() ;
     }
 
     @Test


### PR DESCRIPTION
FEAT : JwtAuthenticationProcessingFilter 에서 인증 처리 중 발생하는 Exception 을 Handling 및 Front-end 로 전달하기 위해 JwtProcessingFilter 앞에 JwtExceptionFilter 를 제작 및 추가했다. 

FIX : 기존에 진행했던 JWT 인증 방식은 AccessToken 이 만료되거나 유효하지 않아도 RefreshToken 이 존재한다면 재발급 그리고 엑세스 토큰만 존재해도 유효하다면 인증에 성공했는데 다른 팀원들과의 협의 끝에 

RefreshToken O / AccessToken O => 통과
RefreshToken O / AccessToken X
=> AccessToken 기간만료 시 ReIssue
=> AccessToken 기간만료 이외의 모든 상황 Forbidden
RefreshToken X / AccessToken O => Forbidden
RefreshToken X / AccessToken X => Forbidden

위와 같은 방식으로 변경되었다. 이번 변경 사항은 이에 따른 수정코드이며 Test 코드 또한 동일한 이유로 수정되었다