### PR TITLE
[REFACTOR] 코드 리팩토링

### DIFF
--- a/src/main/java/com/umbrella/controller/UserController.java
+++ b/src/main/java/com/umbrella/controller/UserController.java
@@ -21,51 +21,35 @@ public class UserController {
     private final LoginService loginService;
 
     @PostMapping(value = "/signUp")
-    public void signUp(@Valid @RequestBody UserRequestSignUpDto userSignUpDto) {
-
-        try {
-            Assert.hasText(userSignUpDto.getEmail(), "email must not be blank");
-            Assert.hasText(userSignUpDto.getNickName(), "nickName must not be blank");
-            Assert.hasText(userSignUpDto.getPassword(), "password must not be blank");
-            Assert.hasText(userSignUpDto.getName(), "mName must not be blank");
-            Assert.hasText(userSignUpDto.getBirthDate(), "birthDate must not be null");
-            Assert.hasText(userSignUpDto.getGender().getGenderValue(), "gender must not be blank");
-        } catch (IllegalArgumentException exception) {
-            /* AOP Exception Handler will Operate */
-        }
-
+    public ResponseEntity signUp(@Valid @RequestBody UserRequestSignUpDto userSignUpDto) {
+        validateSignUpRequest(userSignUpDto);
         userService.signUp(userSignUpDto);
+        return ResponseEntity.ok().body("회원가입이 성공적으로 완료되었습니다!");
     }
 
     @PutMapping(value = "/user/update/info")
-    @ResponseStatus(HttpStatus.OK)
-    public void updateUserInfo(@Valid @RequestBody UserUpdateDto userUpdateDto) {
+    public ResponseEntity updateUserInfo(@Valid @RequestBody UserUpdateDto userUpdateDto) {
         userService.update(userUpdateDto);
+        return ResponseEntity.ok().body("입력하신 정보로 성공적으로 수정되었습니다.");
     }
 
     @PatchMapping(value = "/user/update/password")
-    @ResponseStatus(HttpStatus.OK)
-    public void updateUserPassword(@Valid @RequestBody UpdatePasswordDto updatePasswordDto) {
-        try {
-            Assert.hasText(updatePasswordDto.getCheckPassword(), "checkPassword must not be blank");
-            Assert.hasText(updatePasswordDto.getNewPassword(), "newPassword must not be blank");
-        } catch (IllegalArgumentException exception) {
-            /* AOP Exception Handler will Operate */
-        }
+    public ResponseEntity updateUserPassword(@Valid @RequestBody UpdatePasswordDto updatePasswordDto) {
+        /* AOP Exception Handler will Operate */
+        Assert.hasText(updatePasswordDto.getCheckPassword(), "checkPassword must not be blank");
+        Assert.hasText(updatePasswordDto.getNewPassword(), "newPassword must not be blank");
 
         userService.updatePassword(updatePasswordDto.getCheckPassword(), updatePasswordDto.getNewPassword());
+        return ResponseEntity.ok().body("입력하신 비밀번호로 성공적으로 수정되었습니다.");
     }
 
     @DeleteMapping(value = "/user/withdraw")
-    @ResponseStatus(HttpStatus.OK)
-    public void withdraw(@Valid @RequestBody WithdrawUserDto withdrawUserDto) {
-        try {
-            Assert.hasText(withdrawUserDto.getPassword(), "password must not be blank");
-        } catch (IllegalArgumentException exception) {
-            /* AOP Exception Handler will Operate */
-        }
+    public ResponseEntity withdraw(@Valid @RequestBody WithdrawUserDto withdrawUserDto) {
+        /* AOP Exception Handler will Operate */
+        Assert.hasText(withdrawUserDto.getPassword(), "password must not be blank");
 
         userService.withdraw(withdrawUserDto.getPassword());
+        return ResponseEntity.ok().body("성공적으로 회원탈퇴가 진행되었습니다.");
     }
 
     @PostMapping(value = "/user/{userId}/info")
@@ -80,5 +64,15 @@ public class UserController {
         UserInfoDto userInfoDto = userService.getMyInfo();
 
         return new ResponseEntity(userInfoDto, HttpStatus.OK);
+    }
+
+    private void validateSignUpRequest(UserRequestSignUpDto userSignUpDto) {
+        /* AOP Exception Handler will Operate */
+        Assert.hasText(userSignUpDto.getEmail(), "email must not be blank");
+        Assert.hasText(userSignUpDto.getNickName(), "nickName must not be blank");
+        Assert.hasText(userSignUpDto.getPassword(), "password must not be blank");
+        Assert.hasText(userSignUpDto.getName(), "mName must not be blank");
+        Assert.hasText(userSignUpDto.getBirthDate(), "birthDate must not be null");
+        Assert.hasText(userSignUpDto.getGender().getGenderValue(), "gender must not be blank");
     }
 }

--- a/src/main/java/com/umbrella/domain/exception/UserExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/UserExceptionType.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum UserExceptionType implements BaseExceptionType {
 
     /* SignUp DTO & Login DTO & Update Password DTO & Withdraw DTO Exceptions */
+    DEFAULT_ERROR(699 ,HttpStatus.BAD_REQUEST, "잘못된 인자가 삽입되었습니다."),
     BLANK_PASSWORD_ERROR(600, HttpStatus.BAD_REQUEST, "비밀번호는 필수 입력 값입니다."),
     BLANK_EMAIL_ERROR(601, HttpStatus.BAD_REQUEST, "이메일은 필수 입력 값입니다."),
     BLANK_NICKNAME_ERROR(602, HttpStatus.BAD_REQUEST, "닉네임은 필수 입력 값입니다."),
@@ -18,6 +19,7 @@ public enum UserExceptionType implements BaseExceptionType {
     BLANK_BIRTHDATE_ERROR(604, HttpStatus.BAD_REQUEST, "생년월일은 필수 입력 값입니다."),
     BLANK_GENDER_ERROR(605, HttpStatus.BAD_REQUEST, "성별은 필수 입력 값입니다."),
     UNSUPPORTED_GENDER_ERROR(606, HttpStatus.BAD_REQUEST, "지원하지 않는 성별입니다."),
+
 
     /* UserService Exceptions & Custom OAuth2 User Service */
     DUPLICATE_EMAIL_ERROR(607, HttpStatus.BAD_REQUEST, "동일한 이메일을 사용하는 계정이 이미 존재합니다."),

--- a/src/main/java/com/umbrella/dto/user/UserRequestSignUpDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserRequestSignUpDto.java
@@ -16,7 +16,7 @@ import java.util.Calendar;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRequestSignUpDto {
 
-    @Email(message = "올바른 형식의 이메일 주소여야 합니다")
+    @Email(message = "올바른 형식의 이메일 주소여야 합니다.")
     private String email;
 
     private String nickName;


### PR DESCRIPTION
UserController: 
1) 불필요한 try catch 문 제거
2) 기존에 아무것도 반환하지 않았던 메소드에 ResponseEntity 타입을 반환하게 하는 것으로 로직 실행이 성공적으로 완수되었다는 메세지와 함께 좀 더 명확한 HttpStatus 확인을 가능하게 함
3) signUp 메소드의 Validate 기능들을 추출하여 validateSignUpRequest 메소드로 만듬

UserExceptionType:
DEFAULT_ERROR 를 추가하여 하드코딩된 부분을 줄이도록 함

ExceptionAdvice:
1) DtoIllegalArgumentHandler 에서 return new ResponseEntity 부분이 반복되는 것을 줄이기 위해 swith 사용보다는 Map 을 이용하는 것으로 변경하기로 함. Map 내부에 MESSAGE 를 key 로 하여 UserExceptionType 을 Value 값으로 넣은 후, exception.getMessage() 와 저장된 key 값들을 비교하여 상황에 알맞은 UseExceptionType 을반환하게 만들어 return new ResponseEntity 코드의 중복을 줄임

2) handleValidationException 메소드의 반환 값이 기존에는 errorMessage 들을 길게 나열한 문자열과 에러코드를 반환하는 형식이었지만,  errorMessages 리스트를 다시 한 번 Map 에 넣고 그걸 파싱하여 ResponseEntity 로 전달하는 것으로 Json 객체로 다시금 전달하여 가독성을 높였음

