### PR TITLE
[FEAT] OAuth2 로그인 성공 시 AccessToken, RefreshToken 발급

### DIFF
--- a/src/main/java/com/umbrella/domain/Chat/ChatRoom.java
+++ b/src/main/java/com/umbrella/domain/Chat/ChatRoom.java
@@ -17,7 +17,7 @@ import javax.persistence.Id;
 public class ChatRoom {
 
     @Id @GeneratedValue
-    @Column(name = "chat_romm_id")
+    @Column(name = "chat_room_id")
     private Long chatRoomId;
 
     @Column(columnDefinition = "TEXT" , nullable = false)
@@ -38,5 +38,4 @@ public class ChatRoom {
     public void popUserCount(){
         userCount--;
     }
-
 }

--- a/src/main/java/com/umbrella/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/ExceptionAdvice.java
@@ -2,7 +2,6 @@ package com.umbrella.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umbrella.domain.exception.UserException;
 import com.umbrella.domain.exception.UserExceptionType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/umbrella/exception/GlobalExceptionType.java
+++ b/src/main/java/com/umbrella/exception/GlobalExceptionType.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GlobalExceptionType implements BaseExceptionType{
     ;
-
     private int errorCode;
     private HttpStatus httpStatus;
     private String errorMessage;

--- a/src/main/java/com/umbrella/security/SecurityConfig.java
+++ b/src/main/java/com/umbrella/security/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
         .and()
                 .authorizeRequests()
                 .antMatchers("/login", "/signUp", "/").permitAll()
-                .antMatchers("/oauth2/**", "/auth/**").permitAll()
+                .antMatchers("/auth/**", "/oauth2/**").permitAll()
                 .anyRequest().authenticated()
         .and()
                 .addFilterAfter(jsonEmailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
@@ -79,10 +79,10 @@ public class SecurityConfig {
                                         .failureHandler(oAuth2LoginFailureHandler())
                     )
         .and()
-                .cors().configurationSource(corsConfigurationSource())
-        .and()
-                .exceptionHandling()
-                .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.FORBIDDEN));
+                .cors().configurationSource(corsConfigurationSource());
+//        .and()
+//                .exceptionHandling()
+//                .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.FORBIDDEN));
 
         return http.build();
     }
@@ -138,7 +138,8 @@ public class SecurityConfig {
 
     @Bean
     public OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler() {
-        OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler = new OAuth2LoginSuccessHandler();
+        OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler =
+                new OAuth2LoginSuccessHandler(userRepository, jwtService, cookieOAuth2AuthorizationRequestRepository);
         return oAuth2LoginSuccessHandler;
     }
 

--- a/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
@@ -40,13 +40,13 @@ public class LoginSuccessJWTProvideHandler extends SimpleUrlAuthenticationSucces
         jwtService.setRefreshTokenInCookie(response, refreshToken);
         jwtService.sendAccessToken(response, accessToken);
 
-        User foundUser = userRepository.findByEmail(email)
+        User user = userRepository.findByEmail(email)
                 .orElseThrow( () -> new EntityNotFoundException("찾을 수 없는 계정입니다.") );
 
-        foundUser.updateRefreshToken(refreshToken);
+        user.updateRefreshToken(refreshToken);
 
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("nick_name", foundUser.getNickName());
+        responseMap.put("nick_name", user.getNickName());
         String responseBody = objectMapper.writeValueAsString(responseMap) + "\n성공적으로 로그인이 완료되었습니다!";
 
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/umbrella/security/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/OAuth2LoginSuccessHandler.java
@@ -1,40 +1,50 @@
 package com.umbrella.security.login.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umbrella.domain.User.User;
+import com.umbrella.domain.User.UserRepository;
 import com.umbrella.security.login.cookie.CookieOAuth2AuthorizationRequestRepository;
 import com.umbrella.security.utils.CookieUtil;
 import com.umbrella.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import javax.persistence.EntityNotFoundException;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.umbrella.security.login.cookie.CookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @Log4j2
+@Transactional
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private String redirectUri = "http://localhost:3000/oauth2/redirect";
+    private final UserRepository userRepository;
 
-    @Autowired
-    private JwtService jwtService;
+    private final JwtService jwtService;
 
-    @Autowired
-    private CookieOAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
+    private final CookieOAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
 
     @Autowired
     private CookieUtil cookieUtil;
+
+    private final String redirectUri = "http://localhost:3000/oauth2/redirect";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -51,26 +61,55 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
      protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
          Optional<String> redirectUri = cookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                                                    .map(Cookie::getValue);
+                 .map(Cookie::getValue);
 
          if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
              throw new IllegalArgumentException("Redirect Url 이 일치하지 않습니다!");
          }
 
          String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
-         String email = extractEmail(authentication);
+         String email = extractEmailInAuthentication(authentication);
 
-         String accessToken = jwtService.createAccessToken(email);
-         jwtService.createRefreshToken(email);
+         String accessToken = null;
+         try {
+             accessToken = setTokenAndSendNickname(email, response);
+         } catch (IOException e) {
+             // TODO: need Exception Handling
+             throw new RuntimeException(e);
+         }
 
          return UriComponentsBuilder.fromUriString(targetUrl).queryParam("accessToken", accessToken)
                  .build().toUriString();
      }
 
-    private String extractEmail(Authentication authentication) {
+    private String extractEmailInAuthentication(Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
 
         return userDetails.getUsername();
+    }
+
+    private String setTokenAndSendNickname(String email, HttpServletResponse response) throws IOException {
+        String refreshToken = jwtService.createRefreshToken(email);
+        String accessToken = jwtService.createAccessToken(email);
+
+        jwtService.setRefreshTokenInCookie(response, refreshToken);
+        jwtService.sendAccessToken(response, accessToken);
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("찾을 수 없는 계정입니다."));
+
+        user.updateRefreshToken(refreshToken);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("nick_name", user.getNickName());
+        String responseBody = new ObjectMapper().writeValueAsString(responseMap) + "\n성공적으로 로그인이 완료되었습니다!";
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        response.getWriter().write(responseBody);
+
+        return accessToken;
     }
 
     protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {


### PR DESCRIPTION
OAuth2 로그인이 성공했을 때 AccessToken 과 RefreshToken 을 발급하도록 setTokenAndSendNickname 메소드를 추가함 

추가적으로 기존에는 @Autowired 로 의존성을 주입하던 OAuth2LoginSuccessHandler 내부의 의존성 주입 방식을 생성자 주입으로 변경함. cookieUtil 의 경우 SecurityConfig에서 바로 주입할 수가 없어서 @Autowired 로 유지 