### PR TITLE
[FIX] UserController TEST 코드 전부 실패한 원인을 발견, 수정함

### DIFF
--- a/src/test/java/com/umbrella/project_umbrella/controller/UserControllerTest.java
+++ b/src/test/java/com/umbrella/project_umbrella/controller/UserControllerTest.java
@@ -250,7 +250,7 @@ public class UserControllerTest {
 
         Map<String, Object> passwordUpdateMap = new HashMap<>();
         passwordUpdateMap.put("checkPassword", password);
-        passwordUpdateMap.put("newPassword", password + "!@#@!#@!#");
+        passwordUpdateMap.put("newPassword", password + "!");
 
         String updatePasswordData = objectMapper.writeValueAsString(passwordUpdateMap);
 
@@ -268,7 +268,7 @@ public class UserControllerTest {
                 () -> new EntityNotFoundException("해당 이메일을 사용하는 계정이 존재하지 않습니다.")
         );
         assertThat(passwordEncoder.matches(password, updateUser.getPassword())).isFalse();
-        assertThat(passwordEncoder.matches(password + "!@#@!#@!#", updateUser.getPassword())).isTrue();
+        assertThat(passwordEncoder.matches(password + "!", updateUser.getPassword())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
JwtAuthenticationProcessingFilter 에서 이메일을 추출하는 과정을 리팩토링 했던 코드 때문에 TEST 코드가 전부 실패했음. 사실 정확한 이유는 아직 잘 모르겠어서 조금 더 알아봐야 할 것 같다. 이거 수정하는 김에 람다형식으로 바꿔봄

TEST 코드 수정 내용은 위의 필터 수정과 별개로 비밀번호 정규식 때문에 TEST 코드가 실패했기 때문에 수정된 정규식에 맞게 TEST 코드의 비밀번호 수정