### PR TITLE
[FEAT] Workspace 입장 및 퇴장 기능 추가, Workspace 생성 및 입장 관련 에러 추가

### DIFF
--- a/src/main/java/com/umbrella/controller/UserController.java
+++ b/src/main/java/com/umbrella/controller/UserController.java
@@ -2,6 +2,7 @@ package com.umbrella.controller;
 
 import com.umbrella.dto.user.*;
 import com.umbrella.dto.workspace.WorkspaceRequestCreateDto;
+import com.umbrella.dto.workspace.WorkspaceRequestEnterAndExitDto;
 import com.umbrella.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,8 +78,27 @@ public class UserController {
 
     @PostMapping(value = "/workspace/create")
     public ResponseEntity createWorkspace(@RequestBody WorkspaceRequestCreateDto workspaceRequestCreateDto) {
+        validateCreateWorkspaceRequest(workspaceRequestCreateDto);
         userService.createWorkspace(workspaceRequestCreateDto);
 
         return ResponseEntity.ok().body("워크스페이스가 성공적으로 생성되었습니다.");
+    }
+
+    private void validateCreateWorkspaceRequest(WorkspaceRequestCreateDto workspaceRequestCreateDto) {
+        /* AOP Exception Handler will Operate */
+        Assert.hasText(workspaceRequestCreateDto.getTitle(), "workspace_title must not be blank");
+        Assert.hasText(workspaceRequestCreateDto.getDescription(), "workspace_description must not be blank");
+    }
+
+    @PostMapping(value = "/workspace/enter")
+    public ResponseEntity enterWorkspace(@RequestBody WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto) {
+        userService.enterWorkspace(workspaceRequestEnterDto);
+        return ResponseEntity.ok().body(workspaceRequestEnterDto);
+    }
+
+    @DeleteMapping(value = "/workspace/exit")
+    public ResponseEntity exitWorkspace(@RequestBody WorkspaceRequestEnterAndExitDto workspaceRequestExitDto) {
+        userService.exitWorkspace(workspaceRequestExitDto);
+        return ResponseEntity.ok().body(workspaceRequestExitDto);
     }
 }

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
@@ -1,6 +1,5 @@
 package com.umbrella.domain.WorkSpace;
 
-import com.umbrella.domain.User.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkSpaceRepository.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkSpaceRepository.java
@@ -10,4 +10,6 @@ public interface WorkSpaceRepository extends JpaRepository<WorkSpace,Long> {
     Optional<WorkSpace> findById(Long id);
 
     Optional<WorkSpace> findByTitle(String title);
+
+    Optional<WorkSpace> findByIdAndTitle(Long id, String title);
 }

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUserRepository.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUserRepository.java
@@ -4,9 +4,13 @@ import com.umbrella.domain.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WorkspaceUserRepository extends JpaRepository<WorkspaceUser, Long> {
+
     List<WorkspaceUser> findByWorkspaceUser(User workspaceUser);
 
     List<WorkspaceUser> findByWorkspace(WorkSpace workSpace);
+
+    Optional<WorkspaceUser> findByWorkspaceUserAndWorkspace(User workspaceUser, WorkSpace workSpace);
 }

--- a/src/main/java/com/umbrella/domain/exception/UserExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/UserExceptionType.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum UserExceptionType implements BaseExceptionType {
 
     /* SignUp DTO & Login DTO & Update Password DTO & Withdraw DTO Exceptions */
-    DEFAULT_ERROR(699 ,HttpStatus.BAD_REQUEST, "잘못된 인자가 삽입되었습니다."),
+    DEFAULT_USER_ERROR(699 ,HttpStatus.BAD_REQUEST, "잘못된 인자가 삽입되었습니다."),
     BLANK_PASSWORD_ERROR(600, HttpStatus.BAD_REQUEST, "비밀번호는 필수 입력 값입니다."),
     BLANK_EMAIL_ERROR(601, HttpStatus.BAD_REQUEST, "이메일은 필수 입력 값입니다."),
     BLANK_NICKNAME_ERROR(602, HttpStatus.BAD_REQUEST, "닉네임은 필수 입력 값입니다."),

--- a/src/main/java/com/umbrella/domain/exception/WorkspaceException.java
+++ b/src/main/java/com/umbrella/domain/exception/WorkspaceException.java
@@ -1,0 +1,15 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseException;
+import com.umbrella.exception.BaseExceptionType;
+import lombok.Getter;
+
+@Getter
+public class WorkspaceException extends BaseException {
+
+    private final BaseExceptionType baseExceptionType;
+
+    public WorkspaceException(BaseExceptionType exceptionType) {
+        this.baseExceptionType = exceptionType;
+    }
+}

--- a/src/main/java/com/umbrella/domain/exception/WorkspaceExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/WorkspaceExceptionType.java
@@ -1,0 +1,20 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum WorkspaceExceptionType implements BaseExceptionType {
+    DEFAULT_WORKSPACE_ERROR(700, HttpStatus.BAD_REQUEST, "잘못된 워크스페이스 관련 형식입니다."),
+    ALREADY_ENTERED_WORKSPACE_ERROR(701 ,HttpStatus.BAD_REQUEST, "이미 입장한 워크스페이스 입니다."),
+    BLANK_WORKSPACE_TITLE_ERROR(702 ,HttpStatus.BAD_REQUEST, "워크스페이스의 제목은 필수 입력 값입니다."),
+    BLANK_WORKSPACE_DESCRIPTION_ERROR(703 ,HttpStatus.BAD_REQUEST, "워크스페이스의 설명은 필수 입력 값입니다."),
+    ;
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceRequestEnterAndExitDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceRequestEnterAndExitDto.java
@@ -1,0 +1,22 @@
+package com.umbrella.dto.workspace;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkspaceRequestEnterAndExitDto {
+
+    @Getter
+    private Long id;
+
+    @Getter
+    private String title;
+
+    @Builder
+    public WorkspaceRequestEnterAndExitDto(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/umbrella/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/ExceptionAdvice.java
@@ -2,7 +2,8 @@ package com.umbrella.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umbrella.domain.exception.UserExceptionType;
+import com.umbrella.domain.exception.WorkspaceException;
+import com.umbrella.domain.exception.WorkspaceExceptionType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -17,16 +18,22 @@ import java.util.List;
 import java.util.Map;
 
 import static com.umbrella.domain.exception.UserExceptionType.*;
+import static com.umbrella.domain.exception.WorkspaceExceptionType.*;
 
 @RestControllerAdvice
 public class ExceptionAdvice {
 
-    private static final String EMAIL_ERROR_MESSAGE = "email must not be blank";
-    private static final String NICKNAME_ERROR_MESSAGE = "nickName must not be blank";
-    private static final String PASSWORD_ERROR_MESSAGE = "password must not be blank";
-    private static final String NAME_ERROR_MESSAGE = "mName must not be blank";
-    private static final String BIRTHDATE_ERROR_MESSAGE = "birthDate must not be null";
-    private static final String GENDER_ERROR_MESSAGE = "gender must not be blank";
+    private static final String EMAIL_BLANK_ERROR_MESSAGE = "email must not be blank";
+    private static final String NICKNAME_BLANK_ERROR_MESSAGE = "nickName must not be blank";
+    private static final String PASSWORD_BLANK_ERROR_MESSAGE = "password must not be blank";
+    private static final String NAME_BLANK_ERROR_MESSAGE = "mName must not be blank";
+    private static final String BIRTHDATE_BLANK_ERROR_MESSAGE = "birthDate must not be null";
+    private static final String GENDER_BLANK_ERROR_MESSAGE = "gender must not be blank";
+
+    private static final String WORKSPACE_TITLE_BLANK_ERROR_MESSAGE = "workspace_title must not be blank";
+    private static final String WORKSPACE_DESCRIPTION_BLANK_ERROR_MESSAGE = "workspace_description must not be blank";
+    private static final String ALREADY_ENTERED_WORKSPACE_ERROR_MESSAGE = "이미 입장한 워크스페이스 입니다.";
+
 
     @ExceptionHandler
     public ResponseEntity MainExceptionHandler(BaseException exception){
@@ -36,16 +43,23 @@ public class ExceptionAdvice {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity DtoIllegalArgumentHandler(IllegalArgumentException exception) {
-        Map<String, UserExceptionType> errorMap = new HashMap<>();
-        errorMap.put(EMAIL_ERROR_MESSAGE, BLANK_EMAIL_ERROR);
-        errorMap.put(NICKNAME_ERROR_MESSAGE, BLANK_NICKNAME_ERROR);
-        errorMap.put(PASSWORD_ERROR_MESSAGE, BLANK_PASSWORD_ERROR);
-        errorMap.put(NAME_ERROR_MESSAGE, BLANK_NAME_ERROR);
-        errorMap.put(BIRTHDATE_ERROR_MESSAGE, BLANK_BIRTHDATE_ERROR);
-        errorMap.put(GENDER_ERROR_MESSAGE, BLANK_GENDER_ERROR);
+    public ResponseEntity IllegalArgumentHandler(IllegalArgumentException exception) {
+        Map<String, BaseExceptionType> errorMap = new HashMap<>();
+        /* 유저 회원가입 발생 오류 */
+        errorMap.put(EMAIL_BLANK_ERROR_MESSAGE, BLANK_EMAIL_ERROR);
+        errorMap.put(NICKNAME_BLANK_ERROR_MESSAGE, BLANK_NICKNAME_ERROR);
+        errorMap.put(PASSWORD_BLANK_ERROR_MESSAGE, BLANK_PASSWORD_ERROR);
+        errorMap.put(NAME_BLANK_ERROR_MESSAGE, BLANK_NAME_ERROR);
+        errorMap.put(BIRTHDATE_BLANK_ERROR_MESSAGE, BLANK_BIRTHDATE_ERROR);
+        errorMap.put(GENDER_BLANK_ERROR_MESSAGE, BLANK_GENDER_ERROR);
 
-        UserExceptionType exceptionMap = errorMap.getOrDefault(exception.getMessage(), DEFAULT_ERROR);
+        /* 워크스페이스 생성 발생 오류 */
+        errorMap.put(WORKSPACE_TITLE_BLANK_ERROR_MESSAGE, BLANK_WORKSPACE_TITLE_ERROR);
+        errorMap.put(WORKSPACE_DESCRIPTION_BLANK_ERROR_MESSAGE, BLANK_WORKSPACE_DESCRIPTION_ERROR);
+
+        /* 워크스페이스 입장 발생 오류 */
+        errorMap.put(ALREADY_ENTERED_WORKSPACE_ERROR_MESSAGE, ALREADY_ENTERED_WORKSPACE_ERROR);
+        BaseExceptionType exceptionMap = errorMap.getOrDefault(exception.getMessage(), DEFAULT_USER_ERROR);
 
         return ResponseEntity.status(exceptionMap.getHttpStatus())
                 .body(new ExceptionDto(exceptionMap.getErrorCode(), exceptionMap.getErrorMessage()));

--- a/src/main/java/com/umbrella/service/Impl/UserServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/UserServiceImpl.java
@@ -2,19 +2,21 @@ package com.umbrella.service.Impl;
 
 import com.umbrella.domain.User.User;
 import com.umbrella.domain.WorkSpace.WorkSpace;
+import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
 import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import com.umbrella.domain.WorkSpace.WorkspaceUserRepository;
 import com.umbrella.domain.exception.UserException;
+import com.umbrella.domain.exception.WorkspaceException;
 import com.umbrella.dto.user.UserInfoDto;
 import com.umbrella.dto.user.UserRequestSignUpDto;
 import com.umbrella.dto.user.UserUpdateDto;
 import com.umbrella.domain.User.UserRepository;
 import com.umbrella.dto.workspace.WorkspaceRequestCreateDto;
+import com.umbrella.dto.workspace.WorkspaceRequestEnterAndExitDto;
 import com.umbrella.security.utils.SecurityUtil;
 import com.umbrella.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,7 @@ import javax.persistence.EntityNotFoundException;
 import java.util.Optional;
 
 import static com.umbrella.domain.exception.UserExceptionType.*;
+import static com.umbrella.domain.exception.WorkspaceExceptionType.ALREADY_ENTERED_WORKSPACE_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -34,9 +37,11 @@ public class UserServiceImpl implements UserService {
 
     private final EntityManager entityManager;
 
+    private final UserRepository userRepository;
+
     private final WorkspaceUserRepository workspaceUserRepository;
 
-    private final UserRepository userRepository;
+    private final WorkSpaceRepository workSpaceRepository;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -54,7 +59,7 @@ public class UserServiceImpl implements UserService {
                 .build();
     }
 
-    private User getUserByEmail() {
+    private User getLoginUserByEmail() {
         return userRepository.findByEmail(securityUtil.getLoginUserEmail()).orElseThrow(
                 () -> new UserException(ENTITY_NOT_FOUND_ERROR)
         );
@@ -79,13 +84,13 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void update(UserUpdateDto userUpdateDto) {
-        User wantUpdateUser = getUserByEmail();
+        User wantUpdateUser = getLoginUserByEmail();
         wantUpdateUser.updateUser(userUpdateDto);
     }
 
     @Override
     public void updatePassword(String checkPassword, String newPassword) {
-        User updatePasswordUser = getUserByEmail();
+        User updatePasswordUser = getLoginUserByEmail();
 
         if (!updatePasswordUser.matchPassword(passwordEncoder, checkPassword)) {
             throw new UserException(INCONSISTENCY_PASSWORD_ERROR);
@@ -122,12 +127,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserInfoDto getMyInfo() {
-        User findUser = getUserByEmail();
+        User findUser = getLoginUserByEmail();
 
         return new UserInfoDto(findUser);
     }
 
-    private WorkSpace workspaceCreateDtoToEntity(WorkspaceRequestCreateDto workspaceCreateDto) {
+    private WorkSpace workspaceDtoToEntity(WorkspaceRequestCreateDto workspaceCreateDto) {
 
         return WorkSpace.builder()
                 .title(workspaceCreateDto.getTitle())
@@ -136,25 +141,52 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public WorkspaceUser createWorkspace(WorkspaceRequestCreateDto workspaceCreateDto) {
-        User theUser = getUserByEmail();
-        entityManager.persist(theUser);
+    public Long createWorkspace(WorkspaceRequestCreateDto workspaceCreateDto) {
+        User theUser = getLoginUserByEmail();
+        WorkSpace theWorkspace = workspaceDtoToEntity(workspaceCreateDto);
 
-        WorkSpace theWorkspace = workspaceCreateDtoToEntity(workspaceCreateDto);
+        entityManager.persist(theUser);
         entityManager.persist(theWorkspace);
 
         WorkspaceUser theWorkspaceUser = new WorkspaceUser();
         theUser.enterWorkspaceUser(theWorkspaceUser);
         theWorkspaceUser.takeWorkspace(theWorkspace);
+        workspaceUserRepository.save(theWorkspaceUser);
 
-        return workspaceUserRepository.save(theWorkspaceUser);
+        return theWorkspace.getId();
     }
 
     @Override
-    public void exitWorkspace(Long workspaceId) {
-        User theUser = getUserByEmail();
+    public void enterWorkspace(WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto) {
+        User theUser = getLoginUserByEmail();
+        if (theUser.getWorkspaceUsers().stream().anyMatch( workspaceUser -> {
+            return workspaceUser.getWorkspace().getId() == workspaceRequestEnterDto.getId() &&
+                    workspaceUser.getWorkspace().getTitle().equals(workspaceRequestEnterDto.getTitle());
+        } )) {
+            throw new WorkspaceException(ALREADY_ENTERED_WORKSPACE_ERROR);
+        }
+        Optional<WorkSpace> theWorkspace = workSpaceRepository
+                .findByIdAndTitle(workspaceRequestEnterDto.getId(), workspaceRequestEnterDto.getTitle());
+        if (theWorkspace.isEmpty()) {
+            throw new EntityNotFoundException("해당 워크스페이스는 존재하지 않습니다.");
+        }
+
+        entityManager.persist(theUser);
+        entityManager.persist(theWorkspace.get());
+
+        WorkspaceUser theWorkspaceUser = new WorkspaceUser();
+        theUser.enterWorkspaceUser(theWorkspaceUser);
+        theWorkspaceUser.takeWorkspace(theWorkspace.get());
+
+        workspaceUserRepository.save(theWorkspaceUser);
+    }
+
+    @Override
+    public void exitWorkspace(WorkspaceRequestEnterAndExitDto workspaceRequestEnterAndExitDto) {
+        User theUser = getLoginUserByEmail();
         WorkspaceUser theWorkspaceUser = theUser.getWorkspaceUsers().stream().filter(workspaceUser -> {
-            return workspaceUser.getWorkspace().getId().equals(workspaceId);
+            return workspaceUser.getWorkspace().getId() == (workspaceRequestEnterAndExitDto.getId()) &&
+                    workspaceUser.getWorkspace().getTitle().equals(workspaceRequestEnterAndExitDto.getTitle());
         }).findFirst().orElseThrow(
                 () -> new EntityNotFoundException("해당 워크스페이스를 찾을 수 없습니다!")
         );

--- a/src/main/java/com/umbrella/service/UserService.java
+++ b/src/main/java/com/umbrella/service/UserService.java
@@ -1,11 +1,11 @@
 package com.umbrella.service;
 
 import com.umbrella.domain.User.User;
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import com.umbrella.dto.user.UserInfoDto;
 import com.umbrella.dto.user.UserRequestSignUpDto;
 import com.umbrella.dto.user.UserUpdateDto;
 import com.umbrella.dto.workspace.WorkspaceRequestCreateDto;
+import com.umbrella.dto.workspace.WorkspaceRequestEnterAndExitDto;
 
 public interface UserService {
 
@@ -21,7 +21,9 @@ public interface UserService {
 
     UserInfoDto getMyInfo();
 
-    WorkspaceUser createWorkspace(WorkspaceRequestCreateDto workspaceCreateDto);
+    Long createWorkspace(WorkspaceRequestCreateDto workspaceCreateDto);
 
-    void exitWorkspace(Long workspaceId);
+    void enterWorkspace(WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto);
+
+    void exitWorkspace(WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto);
 }

--- a/src/test/java/com/umbrella/project_umbrella/service/UserServiceTest.java
+++ b/src/test/java/com/umbrella/project_umbrella/service/UserServiceTest.java
@@ -1,7 +1,6 @@
 package com.umbrella.project_umbrella.service;
 
 import com.umbrella.constant.AuthPlatform;
-import com.umbrella.constant.Gender;
 import com.umbrella.constant.Role;
 import com.umbrella.domain.User.User;
 import com.umbrella.domain.WorkSpace.WorkSpace;
@@ -9,11 +8,13 @@ import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
 import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import com.umbrella.domain.WorkSpace.WorkspaceUserRepository;
 import com.umbrella.domain.exception.UserException;
+import com.umbrella.domain.exception.WorkspaceException;
 import com.umbrella.dto.user.UserInfoDto;
 import com.umbrella.dto.user.UserRequestSignUpDto;
 import com.umbrella.dto.user.UserUpdateDto;
 import com.umbrella.domain.User.UserRepository;
 import com.umbrella.dto.workspace.WorkspaceRequestCreateDto;
+import com.umbrella.dto.workspace.WorkspaceRequestEnterAndExitDto;
 import com.umbrella.security.userDetails.UserContext;
 import com.umbrella.security.utils.RoleUtil;
 import com.umbrella.security.utils.SecurityUtil;
@@ -40,6 +41,7 @@ import javax.persistence.EntityNotFoundException;
 
 import java.util.Optional;
 
+import static com.umbrella.domain.exception.UserExceptionType.NOT_FOUND_ERROR;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -73,18 +75,22 @@ public class UserServiceTest {
 
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
-    private String password = "codePirates0204";
+    private static final String nickname = "테스트계정";
 
-    private String birthDate = "20010304";
+    private static final String password = "codePirates0204";
 
-    private String GENDER = "MALE";
+    private static final String name = "홍길동";
 
-    private UserRequestSignUpDto createUserSignUpDto() {
-        return new UserRequestSignUpDto("test@test.com", "테스트계정", password, "홍길동", birthDate, GENDER);
+    private static final String birthDate = "20010304";
+
+    private static final String GENDER = "MALE";
+
+    private UserRequestSignUpDto createUserSignUpDto(int i) {
+        return new UserRequestSignUpDto("test" + i + "@test.com", nickname + i, password, name, birthDate, GENDER);
     }
 
-    private UserRequestSignUpDto setAuthenticationInContext() {
-        UserRequestSignUpDto userSignUpDto = createUserSignUpDto();
+    private UserRequestSignUpDto setAuthenticationInContext(int i) {
+        UserRequestSignUpDto userSignUpDto = createUserSignUpDto(i);
 
         User theUser = userService.signUp(userSignUpDto);
         em.flush();
@@ -112,7 +118,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원가입_성공")
     public void signUpTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = createUserSignUpDto();
+        UserRequestSignUpDto userSignUpDto = createUserSignUpDto(0);
 
         // when
         userService.signUp(userSignUpDto);
@@ -137,7 +143,7 @@ public class UserServiceTest {
     @DisplayName("[FAILED]_회원가입_실패_이메일_중복")
     public void signUpExceptionTest01() {
         // given
-        UserRequestSignUpDto userSignUpDto = createUserSignUpDto();
+        UserRequestSignUpDto userSignUpDto = createUserSignUpDto(0);
 
         userService.signUp(userSignUpDto);
         em.flush();
@@ -152,7 +158,7 @@ public class UserServiceTest {
     @Disabled
     public void signUpExceptionTest02() {
         // given
-        UserRequestSignUpDto userSignUpDto = createUserSignUpDto();
+        UserRequestSignUpDto userSignUpDto = createUserSignUpDto(0);
 
         userService.signUp(userSignUpDto);
         em.flush();
@@ -212,7 +218,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_비밀번호_변경")
     public void updatePasswordTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changePassword = "codePirates0205";
@@ -232,7 +238,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_이름만_변경")
     public void updateMNameTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changeMName = "임꺽정";
@@ -257,7 +263,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_닉네임만_변경")
     public void updateUserNickNameTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changeNickName = "변경테스트";
@@ -282,7 +288,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_나이만_변경")
     public void updateUserAgeTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         int changeAge = 100;
@@ -307,7 +313,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_닉네임과_실명만_변경")
     public void updateUserNickNameAndMNameTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changeNickName = "변경테스트";
@@ -333,7 +339,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_닉네임과_나이만_변경")
     public void updateUserNickNameAndAgeTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changeNickName = "변경테스트";
@@ -359,7 +365,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_실명과_나이만_변경")
     public void updateUserAgeAndMNameTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         int changeAge = 100;
@@ -385,7 +391,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_수정_전부_변경")
     public void updateAllTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         String changeNickName = "변경테스트";
@@ -412,7 +418,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원탈퇴")
     public void withdrawTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         userService.withdraw(password);
@@ -429,7 +435,7 @@ public class UserServiceTest {
     @DisplayName("[FAILED]_회원탈퇴_비밀번호_불일치")
     public void withdrawExceptionTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when, then
         assertThat(assertThrows(UserException.class,
@@ -441,7 +447,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_조회")
     public void getUserInfoTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
         User user = userRepository.findByEmail(userSignUpDto.getEmail()).orElseThrow(
                 () -> new EntityNotFoundException("해당 이메일을 사용하는 계정을 찾을 수 없습니다.")
         );
@@ -460,7 +466,7 @@ public class UserServiceTest {
     @DisplayName("[SUCCESS]_회원정보_내_정보_조회")
     public void getMyInfoTest() {
         // given
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
 
         // when
         UserInfoDto userInfoDto = userService.getMyInfo();
@@ -472,24 +478,45 @@ public class UserServiceTest {
         assertThat(userInfoDto.getNickName()).isEqualTo(userSignUpDto.getNickName());
     }
 
+    private static final String WORKSPACE_TITLE =  "TEST WORKSPACE";
+    private static final String WORKSPACE_DESCRIPTION =  "테스트용 워크스페이스 입니다.";
+    private static final String DUPLICATE_ENTER_WORKSPACE_M = "이미 입장한 워크스페이스 입니다.";
+
     private WorkspaceRequestCreateDto createWorkspaceRequestCreateDto() {
         WorkspaceRequestCreateDto theWorkspaceUserCreateDto = WorkspaceRequestCreateDto.builder()
-                .title("TEST WORKSPACE")
-                .description("테스트용 워크스페이스 입니다.")
+                .title(WORKSPACE_TITLE)
+                .description(WORKSPACE_DESCRIPTION)
                 .build();
 
         return theWorkspaceUserCreateDto;
     }
 
+    private WorkspaceRequestEnterAndExitDto createWorkspaceRequestEnterAndExitDto(Long workspaceId) {
+        WorkspaceRequestEnterAndExitDto theWorkspaceUserEnterDto = WorkspaceRequestEnterAndExitDto.builder()
+                .id(workspaceId)
+                .title(WORKSPACE_TITLE)
+                .build();
+
+        return theWorkspaceUserEnterDto;
+    }
+
     @Test
     @DisplayName("[SUCCESS]_워크스페이스_생성")
     public void createWorkspace() {
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
         WorkspaceRequestCreateDto workspaceRequestCreateDto = createWorkspaceRequestCreateDto();
-        WorkspaceUser theWorkspaceUser = userService.createWorkspace(workspaceRequestCreateDto);
+        Long workspaceId =  userService.createWorkspace(workspaceRequestCreateDto);
+
         User theUser = userRepository.findByEmail(userSignUpDto.getEmail()).orElseThrow(
                 () -> new EntityNotFoundException("해당 이메일을 사용하는 계정을 찾을 수 없습니다.")
         );
+        WorkSpace theWorkspace = workSpaceRepository.findById(workspaceId).orElseThrow(
+                () -> new EntityNotFoundException("해당 워크스페이스를 찾을 수 없습니다.")
+        );
+        WorkspaceUser theWorkspaceUser = workspaceUserRepository.findByWorkspaceUserAndWorkspace(theUser, theWorkspace)
+                .orElseThrow(
+                        () -> new EntityNotFoundException("해당 워크스페이스를 찾을 수 없습니다.")
+                );
 
         assertThat(
                 theWorkspaceUser.getWorkspaceUser().getEmail()
@@ -506,10 +533,41 @@ public class UserServiceTest {
     }
 
     @Test
-    public void exitWorkspaceTest() {
-        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext();
+    @DisplayName("[SUCCESS]_워크스페이스_입장")
+    public void enterWorkspaceTest() {
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
         WorkspaceRequestCreateDto workspaceRequestCreateDto = createWorkspaceRequestCreateDto();
-        WorkspaceUser theWorkspaceUser = userService.createWorkspace(workspaceRequestCreateDto);
+        Long theWorkspaceId = userService.createWorkspace(workspaceRequestCreateDto);
+
+        UserRequestSignUpDto theUserSignUpDto = setAuthenticationInContext(1);
+        WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto = createWorkspaceRequestEnterAndExitDto(theWorkspaceId);
+        userService.enterWorkspace(workspaceRequestEnterDto);
+
+        User theUser = userRepository.findByEmail(securityUtil.getLoginUserEmail()).orElseThrow(
+                () -> new UserException(NOT_FOUND_ERROR)
+        );
+        assertThat(theUser.getWorkspaceUsers().stream().anyMatch( workspaceUser -> {
+            return workspaceUser.getWorkspace().getId() == theWorkspaceId;
+        })).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("[FAILED]_워크스페이스_중복_입장")
+    public void enterWorkspaceFailTest() {
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
+        WorkspaceRequestCreateDto workspaceRequestCreateDto = createWorkspaceRequestCreateDto();
+        Long theWorkspaceId = userService.createWorkspace(workspaceRequestCreateDto);
+        WorkspaceRequestEnterAndExitDto workspaceRequestEnterDto = createWorkspaceRequestEnterAndExitDto(theWorkspaceId);
+
+        assertThrows(WorkspaceException.class, () -> userService.enterWorkspace(workspaceRequestEnterDto));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS]_워크스페이스_퇴장")
+    public void exitWorkspaceTest() {
+        UserRequestSignUpDto userSignUpDto = setAuthenticationInContext(0);
+        WorkspaceRequestCreateDto workspaceRequestCreateDto = createWorkspaceRequestCreateDto();
+        Long workspaceId = userService.createWorkspace(workspaceRequestCreateDto);
 
         User theUser = userRepository.findByEmail(userSignUpDto.getEmail()).orElseThrow(
                 () -> new EntityNotFoundException("해당 이메일을 사용하는 계정을 찾을 수 없습니다.")
@@ -518,8 +576,8 @@ public class UserServiceTest {
         WorkSpace theWorkspace = workSpaceRepository.findByTitle(workspaceRequestCreateDto.getTitle()).orElseThrow(
                 () -> new EntityNotFoundException("해당 워크스페이스를 찾을 수 없습니다.")
         );
-
-        userService.exitWorkspace(theWorkspace.getId());
+        WorkspaceRequestEnterAndExitDto workspaceRequestEnterAndExitDto = createWorkspaceRequestEnterAndExitDto(workspaceId);
+        userService.exitWorkspace(workspaceRequestEnterAndExitDto);
 
         assertThat(theUser.getWorkspaceUsers().size()).isEqualTo(0);
         assertThat(theWorkspace.getWorkspaceUsers().size()).isEqualTo(0);


### PR DESCRIPTION
UserServiceImpl 에 Workspace 입장과 관련된 enterWorkspace 메소드와 퇴장과 관련된 exitWorkspace 추가

두 메소드 모두 id 와 title 두 가지 요소를 검사하여 진행되는데 아무래도 워크스페이스의 핵심 기능이다 보니 조금 더 꼼꼼하게 작성해두었다. 두 메소드는 모두WorkspaceRequestEnterAndExitDto 를 통해 작동되는데 두 메소드 모두 위에서 언급한 것처럼 id 와 title 이라는 공통적인 요소가 필수적이기에 굳이 분리하지 않고 하나의 DTO 로 만들었다.

두 기능 모두 Service 로직까지의 테스트를 성공적으로 마치고 PostMan 으로 작동되는 것까지 확인함. Controller 로직의 테스트는 추후 작성 예정

Controller 단에서는 @PathVariable 이 아닌 @RequestBody 를 통해 객체를 전달받는데, @RequestBody 로 작성한 가장 큰 이유는 id 값을 굳이 노출시키지 않기 위해서이다. 근데 id 값 말고 다른 값을 쓰고 싶다. 다른 좋은 방법이 있는지 알아볼 예정

추가된 예외들은 Workspace 생성시 title 값이 없을 때 발생하는 BLANK_WORKSPACE_TITLE_ERROR, description 값이 없을 때 발생하는 BLANK_WORKSPACE_DESCRIPTION_ERROR 와 Workspace 입장 시 이미 들어와있는 Workspace 에 입장하려고 할 때 발생하는 ALREADY_ENTERED_WORKSPACE_ERROR 다. 