### PR TITLE
[FEAT] WorkspaceController 추가, BoardService 추가, WorkSpaceService 추가

### DIFF
--- a/src/main/java/com/umbrella/controller/WorkSpaceController.java
+++ b/src/main/java/com/umbrella/controller/WorkSpaceController.java
@@ -1,0 +1,50 @@
+package com.umbrella.controller;
+
+import com.umbrella.dto.workspace.WorkspaceRequestDto;
+import com.umbrella.dto.workspace.WorkspaceUpdateRequestDto;
+import com.umbrella.service.Impl.WorkSpaceServiceImpl;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@Getter
+@RequiredArgsConstructor
+public class WorkSpaceController {
+
+    private final WorkSpaceServiceImpl workSpaceService;
+
+    @PostMapping(name = "/workspace")
+    public ResponseEntity<?> save(@Valid @RequestBody WorkspaceRequestDto requestDto){
+        return ResponseEntity.ok().body(workSpaceService.save(requestDto));
+    }
+
+    @GetMapping(name = "/workspace/{workspace_id}")
+    public ResponseEntity<?> findById(@PathVariable Long id){
+        return ResponseEntity.ok().body(workSpaceService.findById(id));
+    }
+
+    @PutMapping(name = "/workspace/{workspace_id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody WorkspaceUpdateRequestDto requestDto){
+        return ResponseEntity.ok().body(workSpaceService.update(id,requestDto));
+    }
+    @DeleteMapping(name = "/workspace/{workspace_id}")
+    public ResponseEntity<?> delete(@PathVariable Long id){
+        return ResponseEntity.ok().body(workSpaceService.delete(id));
+    }
+
+    @GetMapping(name = "/workspace")
+    public ResponseEntity<?> findAll(){
+        return ResponseEntity.ok().body(workSpaceService.findAllList());
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
@@ -37,7 +37,8 @@ public class WorkSpace {
         this.description = description;
     }
 
-    public void updateTitle(String title){
+    public void update(String title, String description){
         this.title = title;
+        this.description = description;
     }
 }

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkSpaceRepository.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkSpaceRepository.java
@@ -1,8 +1,10 @@
 package com.umbrella.domain.WorkSpace;
 
-import com.umbrella.domain.User.User;
+import com.umbrella.dto.workspace.WorkspaceListResponseDto;
+import com.umbrella.dto.workspace.WorkspaceResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WorkSpaceRepository extends JpaRepository<WorkSpace,Long> {
@@ -12,4 +14,9 @@ public interface WorkSpaceRepository extends JpaRepository<WorkSpace,Long> {
     Optional<WorkSpace> findByTitle(String title);
 
     Optional<WorkSpace> findByIdAndTitle(Long id, String title);
+
+    List<WorkspaceResponseDto> findAllDesc();
+
+
+
 }

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUserRepository.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUserRepository.java
@@ -1,6 +1,7 @@
 package com.umbrella.domain.WorkSpace;
 
 import com.umbrella.domain.User.User;
+import com.umbrella.dto.workspace.WorkspaceListResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/umbrella/domain/exception/BoardException.java
+++ b/src/main/java/com/umbrella/domain/exception/BoardException.java
@@ -1,0 +1,14 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseException;
+import com.umbrella.exception.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BoardException extends BaseException {
+
+    private BaseExceptionType baseExceptionType;
+
+}

--- a/src/main/java/com/umbrella/domain/exception/BoardExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/BoardExceptionType.java
@@ -1,0 +1,17 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BoardExceptionType implements BaseExceptionType {
+
+    ;
+
+    private int errorCode;
+    private HttpStatus httpStatus;
+    private String errorMessage;
+}

--- a/src/main/java/com/umbrella/domain/exception/PostExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/PostExceptionType.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PostExceptionType implements BaseExceptionType {
 
-    NOT_FOUND_POST(444,HttpStatus.OK,"존재하지 않는 게시물 입니다."),
+    NOT_FOUND_POST(404,HttpStatus.OK,"존재하지 않는 게시물 입니다."),
     ALREADY_PUSH_ERROR(444,HttpStatus.OK,"이미 좋아요를 눌렀습니다."),
     NON_PUSH_ERROR(444, HttpStatus.OK, "좋아요를 누르지 않았습니다.");
     private int errorCode;

--- a/src/main/java/com/umbrella/domain/exception/WorkspaceExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/WorkspaceExceptionType.java
@@ -12,6 +12,7 @@ public enum WorkspaceExceptionType implements BaseExceptionType {
     ALREADY_ENTERED_WORKSPACE_ERROR(701 ,HttpStatus.BAD_REQUEST, "이미 입장한 워크스페이스 입니다."),
     BLANK_WORKSPACE_TITLE_ERROR(702 ,HttpStatus.BAD_REQUEST, "워크스페이스의 제목은 필수 입력 값입니다."),
     BLANK_WORKSPACE_DESCRIPTION_ERROR(703 ,HttpStatus.BAD_REQUEST, "워크스페이스의 설명은 필수 입력 값입니다."),
+    NOT_FOUNT_WORKSPACE(400, HttpStatus.BAD_REQUEST, "존재하지 않는 워크스페이스입니다.")
     ;
 
     private final int errorCode;

--- a/src/main/java/com/umbrella/dto/board/BoardResponseDto.java
+++ b/src/main/java/com/umbrella/dto/board/BoardResponseDto.java
@@ -1,0 +1,15 @@
+package com.umbrella.dto.board;
+
+import com.umbrella.domain.Board.Board;
+import lombok.Getter;
+
+@Getter
+public class BoardResponseDto {
+
+    private String title;
+
+
+    public BoardResponseDto(Board board){
+        this.title = board.getTitle();
+    }
+}

--- a/src/main/java/com/umbrella/dto/board/BoardSaveRequestDto.java
+++ b/src/main/java/com/umbrella/dto/board/BoardSaveRequestDto.java
@@ -1,0 +1,18 @@
+package com.umbrella.dto.board;
+
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import com.umbrella.service.WorkSpaceService;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BoardSaveRequestDto {
+
+    private Long workSpace_id; //workSpace id;
+    private String title;
+    @Builder
+    public BoardSaveRequestDto(Long workSpace_id, String title){
+        this.workSpace_id = workSpace_id;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/umbrella/dto/board/BoardUpdateRequestDto.java
+++ b/src/main/java/com/umbrella/dto/board/BoardUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.umbrella.dto.board;
+
+import com.umbrella.service.BoardService;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BoardUpdateRequestDto {
+
+    private String title;
+
+    @Builder
+    public BoardUpdateRequestDto(String title){
+        this.title = title;
+    }
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceListResponseDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceListResponseDto.java
@@ -1,0 +1,14 @@
+package com.umbrella.dto.workspace;
+
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import lombok.Getter;
+
+@Getter
+public class WorkspaceListResponseDto {
+
+    private String title;
+
+    public WorkspaceListResponseDto(WorkSpace workSpace){
+        this.title = workSpace.getTitle();
+    }
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceRequestDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceRequestDto.java
@@ -1,0 +1,22 @@
+package com.umbrella.dto.workspace;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Data
+public class WorkspaceRequestDto {
+
+    private String title;
+
+    private String description;
+
+    @Builder
+    public WorkspaceRequestDto(String title, String description){
+        this.title = title;
+        this.description =description;
+    }
+
+
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceResponseDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceResponseDto.java
@@ -1,0 +1,18 @@
+package com.umbrella.dto.workspace;
+
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+@Data
+public class WorkspaceResponseDto {
+
+    private String title;
+    private String description;
+
+    public WorkspaceResponseDto(WorkSpace workSpace){
+        this.title = workSpace.getTitle();
+        this.description = workSpace.getDescription();
+    }
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceUpdateRequestDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.umbrella.dto.workspace;
+
+import lombok.Getter;
+
+@Getter
+public class WorkspaceUpdateRequestDto {
+
+    private Long id;
+
+    private String title;
+
+    private String description;
+
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceUserListResponseDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceUserListResponseDto.java
@@ -1,0 +1,15 @@
+package com.umbrella.dto.workspace;
+
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WorkspaceUserListResponseDto {
+    private String title;
+
+    public WorkspaceUserListResponseDto(WorkspaceUser workspaceUser){
+        this.title = workspaceUser.getWorkspace().getTitle();
+    }
+}

--- a/src/main/java/com/umbrella/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/ExceptionAdvice.java
@@ -2,6 +2,8 @@ package com.umbrella.exception;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umbrella.controller.PostController;
+import com.umbrella.domain.exception.PostException;
 import com.umbrella.domain.exception.WorkspaceException;
 import com.umbrella.domain.exception.WorkspaceExceptionType;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/umbrella/service/BoardService.java
+++ b/src/main/java/com/umbrella/service/BoardService.java
@@ -1,0 +1,25 @@
+package com.umbrella.service;
+
+import com.umbrella.dto.board.BoardResponseDto;
+import com.umbrella.dto.board.BoardSaveRequestDto;
+import com.umbrella.dto.board.BoardUpdateRequestDto;
+import com.umbrella.dto.workspace.WorkspaceListResponseDto;
+
+import java.util.List;
+
+public interface BoardService {
+
+    Long save(BoardSaveRequestDto requestDto);
+
+    Long update(Long id, BoardUpdateRequestDto requestDto);
+
+    Long delete(Long id);
+
+    BoardResponseDto findById(Long id);
+
+    List<BoardResponseDto> findAllDesc();
+
+
+
+
+}

--- a/src/main/java/com/umbrella/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/BoardServiceImpl.java
@@ -1,0 +1,90 @@
+package com.umbrella.service.Impl;
+
+import com.umbrella.domain.Board.Board;
+import com.umbrella.domain.Board.BoardRepository;
+import com.umbrella.domain.User.User;
+import com.umbrella.domain.User.UserRepository;
+import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
+import com.umbrella.domain.WorkSpace.WorkspaceUserRepository;
+import com.umbrella.domain.exception.UserException;
+import com.umbrella.domain.exception.UserExceptionType;
+import com.umbrella.domain.exception.WorkspaceException;
+import com.umbrella.domain.exception.WorkspaceExceptionType;
+import com.umbrella.dto.board.BoardResponseDto;
+import com.umbrella.dto.board.BoardSaveRequestDto;
+import com.umbrella.dto.board.BoardUpdateRequestDto;
+import com.umbrella.security.utils.SecurityUtil;
+import com.umbrella.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+
+    private final BoardRepository boardRepository;
+    private final WorkSpaceRepository workSpaceRepository;
+    private final SecurityUtil securityUtil;
+    private final WorkspaceUserRepository workspaceUserRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public Long save(BoardSaveRequestDto requestDto) {
+        validateUser();
+        Board board = validateWorkSpace(requestDto);
+        return boardRepository.save(board).getId();
+    }
+
+    @Override
+    public Long update(Long id , BoardUpdateRequestDto requestDto) {
+        validateUser();
+        Board board = validateBoard(id);
+        board.update(requestDto.getTitle());
+        return id;
+    }
+
+    @Override
+    public Long delete(Long id) {
+        validateUser();
+        Board board = validateBoard(id);
+        boardRepository.delete(board);
+        return id;
+    }
+
+    @Override
+    public BoardResponseDto findById(Long id) {
+        validateUser();
+        Board board = validateBoard(id);
+        return new BoardResponseDto(board);
+    }
+
+    @Override
+    public List<BoardResponseDto> findAllDesc() {
+        validateUser();
+        return boardRepository.findAll().stream().map(BoardResponseDto::new).collect(Collectors.toList());
+    }
+
+
+    private Board validateWorkSpace(BoardSaveRequestDto requestDto){
+        if(workSpaceRepository.findById(requestDto.getWorkSpace_id()).isEmpty()){
+            throw new WorkspaceException(WorkspaceExceptionType.NOT_FOUNT_WORKSPACE);
+        }
+        return Board.builder().title(requestDto.getTitle()).build();
+    }
+    private Board validateBoard(Long id){
+
+        return boardRepository.findById(id).orElseThrow(() -> new WorkspaceException(WorkspaceExceptionType.NOT_FOUNT_WORKSPACE));
+    }
+
+    private void validateUser(){
+        User user = userRepository.findById(securityUtil.getLoginUserId()).orElseThrow(()-> new UserException(UserExceptionType.NOT_FOUND_ERROR));
+        if(workspaceUserRepository.findByWorkspaceUser(user).isEmpty()){
+            throw new UserException(UserExceptionType.UN_AUTHORIZE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/umbrella/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/PostServiceImpl.java
@@ -45,7 +45,6 @@ public class PostServiceImpl implements PostService {
         Board board = validateBoard(requestDto.getTitle());
         validateUser(findUser);
 
-
         Post post = Post.builder()
                 .content(requestDto.getContent())
                 .writer(findUser.getName())
@@ -77,15 +76,14 @@ public class PostServiceImpl implements PostService {
     }
 
     // 게시글 클릭 메서드
-    public PostResponseDto findById(Long id){
+    public PostResponseDto findById(Long id) {
         Post post = validatePost(id);
         return new PostResponseDto(post);
-
     }
 
     // 게시글 전체 리턴 메서드
     @Transactional(readOnly = true)
-    public Page<PostListResponseDto> findAllPosts(Pageable pageable){
+    public Page<PostListResponseDto> findAllPosts(Pageable pageable) {
         Page<Post> page = postRepository.findAll(pageable);
         Page<PostListResponseDto> map = page.map(PostListResponseDto::new);
 
@@ -112,6 +110,7 @@ public class PostServiceImpl implements PostService {
     }
 
     public Board validateBoard(String title){
+
         return boardRepository.findByTitle(title);
 
     }

--- a/src/main/java/com/umbrella/service/Impl/WorkSpaceServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/WorkSpaceServiceImpl.java
@@ -1,0 +1,82 @@
+package com.umbrella.service.Impl;
+
+import com.umbrella.domain.User.User;
+import com.umbrella.domain.User.UserRepository;
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
+import com.umbrella.domain.WorkSpace.WorkspaceUserRepository;
+import com.umbrella.domain.exception.UserException;
+import com.umbrella.domain.exception.UserExceptionType;
+import com.umbrella.domain.exception.WorkspaceException;
+import com.umbrella.domain.exception.WorkspaceExceptionType;
+import com.umbrella.dto.workspace.*;
+import com.umbrella.security.utils.SecurityUtil;
+import com.umbrella.service.WorkSpaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class WorkSpaceServiceImpl implements WorkSpaceService {
+    private final WorkSpaceRepository workSpaceRepository;
+    private final SecurityUtil securityUtil;
+    private final WorkspaceUserRepository workspaceUserRepository;
+    private final UserRepository userRepository;
+
+    public Long save(WorkspaceRequestDto requestDto){
+
+        WorkSpace workSpace = WorkSpace.builder().
+                title(requestDto.getTitle()).
+                description(requestDto.getDescription())
+                .build();
+
+        return workSpaceRepository.save(workSpace).getId();
+    }
+
+    @Override
+    public Long update(Long id, WorkspaceUpdateRequestDto requestDto) {
+        WorkSpace workSpace = validateWorkspace(id);
+        workSpace.update(requestDto.getTitle(), requestDto.getDescription());
+
+        return id;
+    }
+
+    @Override
+    public Long delete(Long id) {
+        WorkSpace workSpace = validateWorkspace(id);
+        workSpaceRepository.delete(workSpace);
+        return id;
+    }
+
+    @Override
+    public WorkspaceResponseDto findById(Long id) {
+        WorkSpace workSpace = validateWorkspace(id);
+        return new WorkspaceResponseDto(workSpace) ;
+    }
+
+    public List<WorkspaceUserListResponseDto> findAllList(){
+        User user = userRepository.findById(securityUtil.getLoginUserId()).
+                orElseThrow(() -> new UserException(UserExceptionType.NOT_FOUND_ERROR));
+
+        return user.getWorkspaceUsers().stream()
+                .map(WorkspaceUserListResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<WorkspaceListResponseDto> findAllDesc() {
+        return workSpaceRepository.findAll().stream().map(WorkspaceListResponseDto::new).collect(Collectors.toList());
+    }
+
+    public WorkSpace validateWorkspace(Long id){
+
+        return workSpaceRepository.findById(id).orElseThrow(() -> new WorkspaceException(WorkspaceExceptionType.NOT_FOUNT_WORKSPACE));
+    }
+}

--- a/src/main/java/com/umbrella/service/WorkSpaceService.java
+++ b/src/main/java/com/umbrella/service/WorkSpaceService.java
@@ -1,0 +1,21 @@
+package com.umbrella.service;
+
+import com.umbrella.dto.workspace.WorkspaceListResponseDto;
+import com.umbrella.dto.workspace.WorkspaceRequestDto;
+import com.umbrella.dto.workspace.WorkspaceResponseDto;
+import com.umbrella.dto.workspace.WorkspaceUpdateRequestDto;
+
+import java.util.List;
+
+public interface WorkSpaceService {
+
+    Long save(WorkspaceRequestDto requestDto);
+
+    Long update(Long id, WorkspaceUpdateRequestDto requestDto);
+
+    Long delete(Long id);
+
+    WorkspaceResponseDto findById(Long id);
+
+    List<WorkspaceListResponseDto> findAllDesc();
+}


### PR DESCRIPTION
## Summary
WorkspaceController 추가, BoardService 추가, WorkSpaceService 추가

## DevDetails
WorkspaceController 추가,
WorkspaceService 구현,
BoardService CRUD 구현,
BoardException 추가,
BoardExceptionType 추가,
BoardResponseDto, BoardSaveRequestDto, BoardUpdateRequestDto 추가,
WorkSpaceListResponseDto, WorkSpaceUpdateRequestDto, WorkSpaceUserResponseDto 추가,

## ChangeLogic
변화된 로직은 위와 같음, WorkspaceRequestDto 와 WorkspaceCreateDto 의 필드가 동일해 추후 리펙토링 예정


