### PR TITLE
[FEAT] When2Meet 관련된 기능들 추가 및 연관관계 설정

### DIFF
--- a/src/main/java/com/umbrella/controller/UserController.java
+++ b/src/main/java/com/umbrella/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
         return ResponseEntity.ok().body("성공적으로 회원탈퇴가 진행되었습니다.");
     }
 
-    @PostMapping(value = "/user/{userId}/info")
+    @GetMapping(value = "/user/{userId}/info")
     public ResponseEntity getInfo(@Valid @PathVariable("userId") Long id) {
         UserInfoDto userInfoDto = userService.getInfo(id);
 
@@ -78,9 +78,10 @@ public class UserController {
     @GetMapping(value = "/user/info")
     public ResponseEntity getMyInfo() {
         UserInfoDto userInfoDto = userService.getMyInfo();
-
         return new ResponseEntity(userInfoDto, HttpStatus.OK);
     }
+
+    // Workspace 생성, 입장 및 탈퇴 관련
 
     @PostMapping(value = "/workspace/create")
     public ResponseEntity createWorkspace(@RequestBody WorkspaceRequestCreateDto workspaceRequestCreateDto) {

--- a/src/main/java/com/umbrella/controller/WhenToMeetController.java
+++ b/src/main/java/com/umbrella/controller/WhenToMeetController.java
@@ -1,0 +1,46 @@
+package com.umbrella.controller;
+
+import com.umbrella.domain.WhenToMeet.Event;
+import com.umbrella.domain.WhenToMeet.EventRepository;
+import com.umbrella.domain.WhenToMeet.Schedule;
+import com.umbrella.dto.whenToMeet.RequestEventDto;
+import com.umbrella.dto.whenToMeet.RequestScheduleDto;
+import com.umbrella.service.WhenToMeetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api")
+public class WhenToMeetController {
+
+    private final EventRepository eventRepository;
+    private final WhenToMeetService whenToMeetService;
+
+    @GetMapping(value = "/event/{uuid}")
+    public ResponseEntity getEventByUUID(@PathVariable("uuid")UUID uuid) {
+        Optional<Event> theEvent = eventRepository.findEventByUuid(uuid);
+        return theEvent.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/event")
+    public ResponseEntity createEvent(@RequestBody RequestEventDto requestEventDto) {
+        Event theEvent = whenToMeetService.createEvent(requestEventDto);
+        return ResponseEntity.ok().body(theEvent.getUuid());
+    }
+
+    @DeleteMapping("/event/{uuid}/delete")
+    public ResponseEntity deleteEvent(@PathVariable("uuid") UUID uuid) {
+        String theUUID = whenToMeetService.deleteEvent(uuid);
+        return ResponseEntity.ok().body(theUUID);
+    }
+
+    @PostMapping("/event/{uuid}/schedule")
+    public ResponseEntity addSchedule(@PathVariable("uuid") UUID uuid, @RequestBody RequestScheduleDto requestScheduleDto) {
+        Schedule savedSchedule = whenToMeetService.addSchedule(uuid, requestScheduleDto);
+        return ResponseEntity.ok().body(savedSchedule.getDate());
+    }
+}

--- a/src/main/java/com/umbrella/controller/WhenToMeetController.java
+++ b/src/main/java/com/umbrella/controller/WhenToMeetController.java
@@ -3,14 +3,20 @@ package com.umbrella.controller;
 import com.umbrella.domain.WhenToMeet.Event;
 import com.umbrella.domain.WhenToMeet.EventRepository;
 import com.umbrella.domain.WhenToMeet.Schedule;
+import com.umbrella.domain.exception.WhenToMeetException;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
 import com.umbrella.dto.whenToMeet.RequestScheduleDto;
+import com.umbrella.security.utils.SecurityUtil;
 import com.umbrella.service.WhenToMeetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.*;
+
+import static com.umbrella.domain.exception.WhenToMeetExceptionType.NOT_FOUND_EVENT_ERROR;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,24 +27,32 @@ public class WhenToMeetController {
     private final WhenToMeetService whenToMeetService;
 
     @GetMapping(value = "/event/{uuid}")
-    public ResponseEntity getEventByUUID(@PathVariable("uuid")UUID uuid) {
-        Optional<Event> theEvent = eventRepository.findEventByUuid(uuid);
-        return theEvent.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<Map<String, Map<LocalTime, Integer>>> getEventTimeBlockMapByUUID(@PathVariable("uuid") UUID uuid) {
+        Optional<Event> optionalEvent = eventRepository.findEventByUuid(uuid);
+        if (optionalEvent.isEmpty()) {
+           throw new WhenToMeetException(NOT_FOUND_EVENT_ERROR);
+        }
+
+        Event theEvent = optionalEvent.get();
+        List<Schedule> schedules = theEvent.getSchedules();
+
+        Map<String, Map<LocalTime, Integer>> timeBlockInSchedule = whenToMeetService.getScheduleInEvent(schedules);
+        return ResponseEntity.ok(timeBlockInSchedule);
     }
 
-    @PostMapping("/event")
+    @PostMapping(value= "/event")
     public ResponseEntity createEvent(@RequestBody RequestEventDto requestEventDto) {
         Event theEvent = whenToMeetService.createEvent(requestEventDto);
         return ResponseEntity.ok().body(theEvent.getUuid());
     }
 
-    @DeleteMapping("/event/{uuid}/delete")
+    @DeleteMapping(value = "/event/{uuid}/delete")
     public ResponseEntity deleteEvent(@PathVariable("uuid") UUID uuid) {
         String theUUID = whenToMeetService.deleteEvent(uuid);
         return ResponseEntity.ok().body(theUUID);
     }
 
-    @PostMapping("/event/{uuid}/schedule")
+    @PostMapping(value = "/event/{uuid}/schedule")
     public ResponseEntity addSchedule(@PathVariable("uuid") UUID uuid, @RequestBody RequestScheduleDto requestScheduleDto) {
         Schedule savedSchedule = whenToMeetService.addSchedule(uuid, requestScheduleDto);
         return ResponseEntity.ok().body(savedSchedule.getDate());

--- a/src/main/java/com/umbrella/controller/WhenToMeetController.java
+++ b/src/main/java/com/umbrella/controller/WhenToMeetController.java
@@ -3,6 +3,7 @@ package com.umbrella.controller;
 import com.umbrella.domain.WhenToMeet.Event;
 import com.umbrella.domain.WhenToMeet.EventRepository;
 import com.umbrella.domain.WhenToMeet.Schedule;
+import com.umbrella.domain.WhenToMeet.ScheduleRepository;
 import com.umbrella.domain.exception.WhenToMeetException;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
 import com.umbrella.dto.whenToMeet.RequestScheduleDto;
@@ -24,6 +25,7 @@ import static com.umbrella.domain.exception.WhenToMeetExceptionType.NOT_FOUND_EV
 public class WhenToMeetController {
 
     private final EventRepository eventRepository;
+    private final ScheduleRepository scheduleRepository;
     private final WhenToMeetService whenToMeetService;
 
     @GetMapping(value = "/event/{uuid}")
@@ -56,5 +58,11 @@ public class WhenToMeetController {
     public ResponseEntity addSchedule(@PathVariable("uuid") UUID uuid, @RequestBody RequestScheduleDto requestScheduleDto) {
         Schedule savedSchedule = whenToMeetService.addSchedule(uuid, requestScheduleDto);
         return ResponseEntity.ok().body(savedSchedule.getDate());
+    }
+
+    @PostMapping(value = "/event/{uuid}/schedule/modify")
+    public ResponseEntity modifySchedule(@PathVariable("uuid") UUID uuid, @RequestBody RequestScheduleDto requestScheduleDto) {
+        Schedule savedSchedule = whenToMeetService.modifySchedule(uuid, requestScheduleDto);
+        return ResponseEntity.ok().body(savedSchedule.getTimeBlocks());
     }
 }

--- a/src/main/java/com/umbrella/controller/WhenToMeetController.java
+++ b/src/main/java/com/umbrella/controller/WhenToMeetController.java
@@ -3,17 +3,14 @@ package com.umbrella.controller;
 import com.umbrella.domain.WhenToMeet.Event;
 import com.umbrella.domain.WhenToMeet.EventRepository;
 import com.umbrella.domain.WhenToMeet.Schedule;
-import com.umbrella.domain.WhenToMeet.ScheduleRepository;
 import com.umbrella.domain.exception.WhenToMeetException;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
 import com.umbrella.dto.whenToMeet.RequestScheduleDto;
-import com.umbrella.security.utils.SecurityUtil;
 import com.umbrella.service.WhenToMeetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
 
@@ -25,7 +22,6 @@ import static com.umbrella.domain.exception.WhenToMeetExceptionType.NOT_FOUND_EV
 public class WhenToMeetController {
 
     private final EventRepository eventRepository;
-    private final ScheduleRepository scheduleRepository;
     private final WhenToMeetService whenToMeetService;
 
     @GetMapping(value = "/event/{uuid}")

--- a/src/main/java/com/umbrella/controller/WorkSpaceController.java
+++ b/src/main/java/com/umbrella/controller/WorkSpaceController.java
@@ -23,7 +23,7 @@ public class WorkSpaceController {
     }
 
     @GetMapping(value = "/workspace/{workspace_id}")
-    public ResponseEntity<?> findById(@PathVariable Long id){
+    public ResponseEntity<?> findById(@PathVariable("workspace_id") Long id){
         return ResponseEntity.ok().body(workSpaceService.findById(id));
     }
 

--- a/src/main/java/com/umbrella/domain/User/UserRepository.java
+++ b/src/main/java/com/umbrella/domain/User/UserRepository.java
@@ -1,6 +1,5 @@
 package com.umbrella.domain.User;
 
-import com.umbrella.domain.User.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -14,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByRefreshToken(String refreshToken);
+
+    Optional<User> findByEmailOrNickName(String email, String nickName);
 }

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
@@ -2,6 +2,7 @@ package com.umbrella.domain.WhenToMeet;
 
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
@@ -23,7 +24,8 @@ public class Event {
     @Setter
     @GeneratedValue(strategy = GenerationType.AUTO)
     @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(name = "uuid", columnDefinition = "VARCHAR(255)", updatable = false, nullable = false)
+    @Type(type = "org.hibernate.type.UUIDCharType")
+    @Column(name = "uuid", length = 36, updatable = false, nullable = false)
     private UUID uuid;
 
     @NotEmpty
@@ -45,6 +47,7 @@ public class Event {
     @Column(name = "event_members")
     private List<String> members;
 
+    @Setter
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     @Column(name = "schedules")
     private List<Schedule> schedules;

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
@@ -1,7 +1,6 @@
 package com.umbrella.domain.WhenToMeet;
 
 import com.umbrella.domain.WorkSpace.WorkSpace;
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Event.java
@@ -1,5 +1,7 @@
 package com.umbrella.domain.WhenToMeet;
 
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
@@ -28,6 +30,10 @@ public class Event {
     @Column(name = "uuid", length = 36, updatable = false, nullable = false)
     private UUID uuid;
 
+    @ManyToOne
+    @JoinColumn(name = "workspace_id")
+    private WorkSpace workSpace;
+
     @NotEmpty
     @Column(name = "title")
     private String title;
@@ -42,22 +48,17 @@ public class Event {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date endDate;
 
-    @NotEmpty
-    @ElementCollection
-    @Column(name = "event_members")
-    private List<String> members;
-
     @Setter
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     @Column(name = "schedules")
     private List<Schedule> schedules;
 
     @Builder
-    public Event(String title, Date startDate, Date endDate, List<String> members) {
+    public Event(WorkSpace workSpace, String title, Date startDate, Date endDate) {
+        this.workSpace = workSpace;
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.members = members;
     }
 
     @PrePersist

--- a/src/main/java/com/umbrella/domain/WhenToMeet/EventRepository.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/EventRepository.java
@@ -2,5 +2,10 @@ package com.umbrella.domain.WhenToMeet;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    Optional<Event> findEventByUuid(UUID uuid);
 }

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
@@ -7,7 +7,11 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotEmpty;
+import java.sql.Timestamp;
+import java.time.LocalTime;
 import java.util.Date;
+import java.util.List;
 
 @Getter
 @Entity(name = "schedule")
@@ -19,20 +23,27 @@ public class Schedule {
     @Column(name = "schedule_id")
     private long id;
 
-    @Column(name = "members")
-    private String members;
+    @ManyToOne
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Column(name = "member")
+    private String member;
 
     @Column(name = "date")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date date;
 
-    @ManyToOne
-    @JoinColumn(name = "event_id")
-    private Event event;
+    @Column(name = "time_block")
+    @ElementCollection
+    @DateTimeFormat(pattern = "HH:mm")
+    private List<LocalTime> timeBlocks;
 
     @Builder
-    public Schedule(String members, Date date) {
-        this.members = members;
+    public Schedule(Event event, String member, Date date, List<LocalTime> timeBlocks) {
+        this.event = event;
+        this.member = member;
         this.date = date;
+        this.timeBlocks = timeBlocks;
     }
 }

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
@@ -1,6 +1,5 @@
 package com.umbrella.domain.WhenToMeet;
 
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/Schedule.java
@@ -1,5 +1,6 @@
 package com.umbrella.domain.WhenToMeet;
 
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,8 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotEmpty;
-import java.sql.Timestamp;
+import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 import java.util.Date;
 import java.util.List;
@@ -27,8 +27,9 @@ public class Schedule {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @Column(name = "member")
-    private String member;
+    @NotNull
+    @Column(name = "schedule_member")
+    private Long userId;
 
     @Column(name = "date")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -40,9 +41,9 @@ public class Schedule {
     private List<LocalTime> timeBlocks;
 
     @Builder
-    public Schedule(Event event, String member, Date date, List<LocalTime> timeBlocks) {
+    public Schedule(Event event, Long userId, Date date, List<LocalTime> timeBlocks) {
         this.event = event;
-        this.member = member;
+        this.userId = userId;
         this.date = date;
         this.timeBlocks = timeBlocks;
     }

--- a/src/main/java/com/umbrella/domain/WhenToMeet/ScheduleRepository.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/ScheduleRepository.java
@@ -3,5 +3,5 @@ package com.umbrella.domain.WhenToMeet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-    void deleteByEventAndMember(Event event, String member);
+    void deleteByEventAndUserId(Event event, Long userId);
 }

--- a/src/main/java/com/umbrella/domain/WhenToMeet/ScheduleRepository.java
+++ b/src/main/java/com/umbrella/domain/WhenToMeet/ScheduleRepository.java
@@ -3,4 +3,5 @@ package com.umbrella.domain.WhenToMeet;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    void deleteByEventAndMember(Event event, String member);
 }

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkSpace.java
@@ -1,5 +1,6 @@
 package com.umbrella.domain.WorkSpace;
 
+import com.umbrella.domain.WhenToMeet.Event;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,8 +29,11 @@ public class WorkSpace {
     @NotBlank
     private String description;
 
-    @OneToMany(mappedBy = "workspace")
+    @OneToMany(mappedBy = "workspace", cascade = CascadeType.PERSIST)
     private List<WorkspaceUser> workspaceUsers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "workSpace", cascade = CascadeType.ALL)
+    private List<Event> events = new ArrayList<>();
 
     @Builder
     public WorkSpace(String title, String description){

--- a/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUser.java
+++ b/src/main/java/com/umbrella/domain/WorkSpace/WorkspaceUser.java
@@ -17,7 +17,7 @@ public class WorkspaceUser {
     private Long id;
 
     @Setter
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "workspace_id")
     private WorkSpace workspace;
 

--- a/src/main/java/com/umbrella/domain/exception/WhenToMeetException.java
+++ b/src/main/java/com/umbrella/domain/exception/WhenToMeetException.java
@@ -1,0 +1,14 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseExceptionType;
+import lombok.Getter;
+
+@Getter
+public class WhenToMeetException extends RuntimeException {
+
+    private final BaseExceptionType baseExceptionType;
+
+    public WhenToMeetException(BaseExceptionType exceptionType) {
+        this.baseExceptionType = exceptionType;
+    }
+}

--- a/src/main/java/com/umbrella/domain/exception/WhenToMeetExceptionType.java
+++ b/src/main/java/com/umbrella/domain/exception/WhenToMeetExceptionType.java
@@ -1,0 +1,22 @@
+package com.umbrella.domain.exception;
+
+import com.umbrella.exception.BaseExceptionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum WhenToMeetExceptionType implements BaseExceptionType {
+
+    DEFAULT_WHEN2MEET_ERROR(899, HttpStatus.BAD_REQUEST, "알 수 없는 에러가 발생했습니다."),
+
+    /* Event 관련 에러 */
+    NOT_FOUND_EVENT_ERROR(800 ,HttpStatus.BAD_REQUEST, "해당 이벤트를 찾을 수 없습니다."),
+    ILLEGAL_DATE_RANGE_ERROR(801 ,HttpStatus.BAD_REQUEST, "날짜의 범위가 잘못 지정되었습니다."),
+    ;
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+}

--- a/src/main/java/com/umbrella/dto/email/EmailAuthResponseDto.java
+++ b/src/main/java/com/umbrella/dto/email/EmailAuthResponseDto.java
@@ -1,10 +1,13 @@
 package com.umbrella.dto.email;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailAuthResponseDto {
     @Getter

--- a/src/main/java/com/umbrella/dto/user/UserInfoDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserInfoDto.java
@@ -2,20 +2,23 @@ package com.umbrella.dto.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.umbrella.domain.User.User;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserInfoDto {
 
-    private final String email;
+    private String email;
 
-    private final String name;
+    private String name;
 
     @JsonProperty("nick_name")
-    private final String nickName;
+    private String nickName;
 
-    private final Integer age;
+    private Integer age;
 
     @Builder
     public UserInfoDto(User findUser) {

--- a/src/main/java/com/umbrella/dto/user/UserRequestFindPasswordDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserRequestFindPasswordDto.java
@@ -1,8 +1,11 @@
 package com.umbrella.dto.user;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRequestFindPasswordDto {
 
     @Getter

--- a/src/main/java/com/umbrella/dto/user/UserRequestLoginDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserRequestLoginDto.java
@@ -1,20 +1,23 @@
 package com.umbrella.dto.user;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRequestLoginDto {
 
     @Email(message = "올바른 형식의 이메일 주소여야 합니다")
-    private final String email;
+    private String email;
 
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
             message = "비밀번호는 8 ~ 20 자리이면서 1개 이상의 알파벳, 숫자, 특수문자를 포함해야 합니다.")
-    private final String password;
+    private String password;
 
     @Builder
     public UserRequestLoginDto(String email, String password) {

--- a/src/main/java/com/umbrella/dto/user/UserRequestUpdateDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserRequestUpdateDto.java
@@ -1,11 +1,14 @@
 package com.umbrella.dto.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Optional;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRequestUpdateDto {
 
     @Getter

--- a/src/main/java/com/umbrella/dto/user/UserRequestUpdatePasswordDto.java
+++ b/src/main/java/com/umbrella/dto/user/UserRequestUpdatePasswordDto.java
@@ -2,22 +2,25 @@ package com.umbrella.dto.user;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Pattern;
 
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRequestUpdatePasswordDto {
 
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
             message = "비밀번호는 8 ~ 20 자리이면서 1개 이상의 알파벳, 숫자, 특수문자를 포함해야 합니다.")
-    private final String checkPassword;
+    private String checkPassword;
 
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
             message = "비밀번호는 8 ~ 20 자리이면서 1개 이상의 알파벳, 숫자, 특수문자를 포함해야 합니다.")
-    private final String newPassword;
+    private String newPassword;
 
     @Builder
     public UserRequestUpdatePasswordDto(String checkPassword, String newPassword) {

--- a/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
+++ b/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
@@ -2,16 +2,19 @@ package com.umbrella.dto.whenToMeet;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
-import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestEventDto {
+
+    @Getter
+    private Long workspaceId;
 
     @Getter
     private String title;
@@ -21,7 +24,4 @@ public class RequestEventDto {
 
     @Getter
     private Date endDate;
-
-    @Getter
-    private List<String> members;
 }

--- a/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
+++ b/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
@@ -2,7 +2,6 @@ package com.umbrella.dto.whenToMeet;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
+++ b/src/main/java/com/umbrella/dto/whenToMeet/RequestEventDto.java
@@ -1,0 +1,27 @@
+package com.umbrella.dto.whenToMeet;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestEventDto {
+
+    @Getter
+    private String title;
+
+    @Getter
+    private Date startDate;
+
+    @Getter
+    private Date endDate;
+
+    @Getter
+    private List<String> members;
+}

--- a/src/main/java/com/umbrella/dto/whenToMeet/RequestScheduleDto.java
+++ b/src/main/java/com/umbrella/dto/whenToMeet/RequestScheduleDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestScheduleDto {
 
-    private List<LocalTime> timeBlocks;
-
     private Date date;
+
+    private List<LocalTime> timeBlocks;
 }

--- a/src/main/java/com/umbrella/dto/whenToMeet/RequestScheduleDto.java
+++ b/src/main/java/com/umbrella/dto/whenToMeet/RequestScheduleDto.java
@@ -1,0 +1,21 @@
+package com.umbrella.dto.whenToMeet;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestScheduleDto {
+
+    private List<LocalTime> timeBlocks;
+
+    private Date date;
+}

--- a/src/main/java/com/umbrella/dto/workspace/EventResponseDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/EventResponseDto.java
@@ -1,0 +1,19 @@
+package com.umbrella.dto.workspace;
+
+import com.umbrella.domain.WhenToMeet.Event;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventResponseDto {
+
+    private Long eventId;
+    private String title;
+
+    public EventResponseDto(Event event) {
+        this.eventId = event.getId();
+        this.title = event.getTitle();
+    }
+}

--- a/src/main/java/com/umbrella/dto/workspace/WorkspaceResponseDto.java
+++ b/src/main/java/com/umbrella/dto/workspace/WorkspaceResponseDto.java
@@ -1,8 +1,12 @@
 package com.umbrella.dto.workspace;
 
+import com.umbrella.domain.WhenToMeet.Event;
 import com.umbrella.domain.WorkSpace.WorkSpace;
 import lombok.Data;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Data
@@ -10,9 +14,11 @@ public class WorkspaceResponseDto {
 
     private String title;
     private String description;
+    private List<EventResponseDto> events;
 
     public WorkspaceResponseDto(WorkSpace workSpace){
         this.title = workSpace.getTitle();
         this.description = workSpace.getDescription();
+        this.events = workSpace.getEvents().stream().map(EventResponseDto::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.umbrella.exception;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umbrella.domain.exception.UserException;
+import com.umbrella.domain.exception.WhenToMeetException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -41,6 +42,14 @@ public class UserExceptionAdvice {
                 exception.getBaseExceptionType().getHttpStatus());
     }
 
+    @ExceptionHandler(WhenToMeetException.class)
+    public ResponseEntity When2MeetExceptionHandler(UserException exception){
+
+        return new ResponseEntity(new ExceptionDto(exception.getBaseExceptionType().getErrorCode(),
+                exception.getBaseExceptionType().getErrorMessage()),
+                exception.getBaseExceptionType().getHttpStatus());
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity IllegalArgumentHandler(IllegalArgumentException exception) {
         Map<String, BaseExceptionType> errorMap = new HashMap<>();
@@ -58,6 +67,7 @@ public class UserExceptionAdvice {
 
         /* 워크스페이스 입장 발생 오류 */
         errorMap.put(ALREADY_ENTERED_WORKSPACE_ERROR_MESSAGE, ALREADY_ENTERED_WORKSPACE_ERROR);
+
         BaseExceptionType exceptionMap = errorMap.getOrDefault(exception.getMessage(), DEFAULT_USER_ERROR);
 
         return ResponseEntity.status(exceptionMap.getHttpStatus())

--- a/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umbrella.domain.exception.UserException;
 import com.umbrella.domain.exception.WhenToMeetException;
+import com.umbrella.domain.exception.WorkspaceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -36,6 +37,14 @@ public class UserExceptionAdvice {
 
     @ExceptionHandler(UserException.class)
     public ResponseEntity MainExceptionHandler(UserException exception){
+
+        return new ResponseEntity(new ExceptionDto(exception.getBaseExceptionType().getErrorCode(),
+                exception.getBaseExceptionType().getErrorMessage()),
+                exception.getBaseExceptionType().getHttpStatus());
+    }
+
+    @ExceptionHandler(WorkspaceException.class)
+    public ResponseEntity WorkspaceExceptionHandler(WorkspaceException exception){
 
         return new ResponseEntity(new ExceptionDto(exception.getBaseExceptionType().getErrorCode(),
                 exception.getBaseExceptionType().getErrorMessage()),

--- a/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
+++ b/src/main/java/com/umbrella/exception/UserExceptionAdvice.java
@@ -43,7 +43,7 @@ public class UserExceptionAdvice {
     }
 
     @ExceptionHandler(WhenToMeetException.class)
-    public ResponseEntity When2MeetExceptionHandler(UserException exception){
+    public ResponseEntity When2MeetExceptionHandler(WhenToMeetException exception){
 
         return new ResponseEntity(new ExceptionDto(exception.getBaseExceptionType().getErrorCode(),
                 exception.getBaseExceptionType().getErrorMessage()),

--- a/src/main/java/com/umbrella/security/SecurityConfig.java
+++ b/src/main/java/com/umbrella/security/SecurityConfig.java
@@ -15,11 +15,13 @@ import com.umbrella.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -49,6 +51,12 @@ public class SecurityConfig {
     private final RoleUtil roleUtil;
 
     @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().antMatchers(HttpMethod.POST, "/login", "/signUp", "/", "/send-email",
+                "/auth/**", "/oauth2/**");
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .formLogin().disable()
@@ -57,8 +65,6 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
                 .authorizeRequests()
-                .antMatchers("/login", "/signUp", "/", "/send-email").permitAll()
-                .antMatchers("/auth/**", "/oauth2/**").permitAll()
                 .anyRequest().authenticated()
         .and()
                 .addFilterAfter(jsonEmailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/umbrella/security/login/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/umbrella/security/login/filter/JwtAuthenticationProcessingFilter.java
@@ -4,7 +4,6 @@ import com.umbrella.domain.User.User;
 import com.umbrella.domain.User.UserRepository;
 import com.umbrella.security.userDetails.UserContext;
 import com.umbrella.security.utils.RoleUtil;
-import com.umbrella.security.utils.SecurityUtil;
 import com.umbrella.service.JwtService;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,6 @@ import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 @Slf4j
 @Component

--- a/src/main/java/com/umbrella/security/login/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/umbrella/security/login/filter/JwtAuthenticationProcessingFilter.java
@@ -64,9 +64,10 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         );
 
         String email = jwtService.extractEmail(extractAccessToken).get();
+        String nickName = jwtService.extractNickName(extractAccessToken).get();
 
         if (jwtService.isTokenValid(extractRefreshToken) == PASS) {
-            checkAccessToken(response, extractAccessToken, email);
+            checkAccessToken(response, extractAccessToken, email, nickName);
             checkAndSaveAuthentication(email);
         } else {
             throw new JwtException(REFRESH_TOKEN_ERROR_M);
@@ -75,13 +76,13 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         doFilter(request, response, filterChain);
     }
 
-    private void checkAccessToken(HttpServletResponse response, String accessToken, String email) {
+    private void checkAccessToken(HttpServletResponse response, String accessToken, String email, String nickName) {
         switch (jwtService.isTokenValid(accessToken)) {
             case PASS:
                 jwtService.sendAccessToken(response, accessToken);
                 break;
             case REISSUE:
-                jwtService.sendAccessToken(response, jwtService.createAccessToken(email));
+                jwtService.sendAccessToken(response, jwtService.createAccessToken(email, nickName));
                 break;
             default:
                 throw new JwtException(ACCESS_TOKEN_ERROR_M);

--- a/src/main/java/com/umbrella/security/login/handler/LoginFailureHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/LoginFailureHandler.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
@@ -1,17 +1,16 @@
 package com.umbrella.security.login.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umbrella.domain.User.User;
 import com.umbrella.domain.User.UserRepository;
+import com.umbrella.security.userDetails.UserContext;
 import com.umbrella.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 
-import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -31,38 +30,52 @@ public class LoginSuccessJWTProvideHandler extends SimpleUrlAuthenticationSucces
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-        String email = extractEmail(authentication);
-        String accessToken = jwtService.createAccessToken(email);
+        String email = getEmailFromAuthentication(authentication);
+        String nickName = getNickNameFromAuthentication(authentication);
+
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         jwtService.setRefreshTokenInCookie(response, refreshToken);
         jwtService.sendAccessToken(response, accessToken);
 
-        User user = userRepository.findByEmail(email)
-                .orElseThrow( () -> new EntityNotFoundException("찾을 수 없는 계정입니다.") );
+        userRepository.findByEmail(email).ifPresent(user -> user.updateRefreshToken(refreshToken));
 
-        user.updateRefreshToken(refreshToken);
+        String responseBody = createLoginSuccessResponse(nickName);
 
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("nick_name", user.getNickName());
-        String responseBody = objectMapper.writeValueAsString(responseMap) + "\n성공적으로 로그인이 완료되었습니다!";
+        sendResponse(response, responseBody);
 
+        logSuccess(email, accessToken, refreshToken);
+    }
+
+    private void logSuccess(String email, String accessToken, String refreshToken) {
+        log.info( "로그인에 성공합니다. email: {}", email);
+        log.info( "AccessToken 을 발급합니다. AccessToken: {}", accessToken);
+        log.info( "RefreshToken 을 발급합니다. RefreshToken: {}", refreshToken);
+    }
+
+    private void sendResponse(HttpServletResponse response, String responseBody) throws IOException {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
         response.getWriter().write(responseBody);
         response.getWriter().flush();
         response.getWriter().close();
-
-        log.info( "로그인에 성공합니다. email: {}", email);
-        log.info( "AccessToken 을 발급합니다. AccessToken: {}", accessToken);
-        log.info( "RefreshToken 을 발급합니다. RefreshToken: {}", refreshToken);
     }
 
-    private String extractEmail(Authentication authentication) {
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    private String createLoginSuccessResponse(String nickName) throws JsonProcessingException {
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("nick_name", nickName);
+        String responseBody = objectMapper.writeValueAsString(responseMap) + "\n성공적으로 로그인이 완료되었습니다!";
+        return responseBody;
+    }
 
-        return userDetails.getUsername();
+    private String getEmailFromAuthentication(Authentication authentication) {
+        return ((UserContext) authentication.getPrincipal()).getUsername();
+    }
+
+    private String getNickNameFromAuthentication(Authentication authentication) {
+        return ((UserContext) authentication.getPrincipal()).getNickName();
     }
 }
 

--- a/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/LoginSuccessJWTProvideHandler.java
@@ -13,12 +13,14 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.transaction.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
+@Transactional
 @RequiredArgsConstructor
 public class LoginSuccessJWTProvideHandler extends SimpleUrlAuthenticationSuccessHandler {
 

--- a/src/main/java/com/umbrella/security/login/handler/LogoutSuccessHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/LogoutSuccessHandler.java
@@ -1,9 +1,7 @@
 package com.umbrella.security.login.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umbrella.security.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;

--- a/src/main/java/com/umbrella/security/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/umbrella/security/login/handler/OAuth2LoginSuccessHandler.java
@@ -12,7 +12,6 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/src/main/java/com/umbrella/security/userDetails/UserContext.java
+++ b/src/main/java/com/umbrella/security/userDetails/UserContext.java
@@ -1,5 +1,6 @@
 package com.umbrella.security.userDetails;
 
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
@@ -58,6 +59,7 @@ public class UserContext implements UserDetails, OAuth2User {
         this(username, password, id, nickName, authorities, true, true, true, true);
     }
 
+    // OAuth2
     public UserContext(String username, String password, Long id, String nickName,
                        Set<GrantedAuthority> authorities, Map<String, Object> attributes,
                        boolean accountNonExpired, boolean accountNonLocked, boolean credentialsNonExpired, boolean enabled) {

--- a/src/main/java/com/umbrella/service/Impl/JwtServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/JwtServiceImpl.java
@@ -72,13 +72,16 @@ public class JwtServiceImpl implements JwtService {
 
     @Override
     public String createAccessToken(String email, String nickName) {
+        Claims claims = Jwts.claims();
+        claims.put(EMAIL_CLAIM, email);
+        claims.put(NICK_NAME_CLAIM, nickName);
+
         return Jwts.builder()
                 .signWith(secretKey, SIGNATURE_ALGORITHM)
                 .setSubject(email)
                 .setIssuer(ISSUER)
                 .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration * 1000))
-                .claim(EMAIL_CLAIM, email)
-                .claim(NICK_NAME_CLAIM, nickName)
+                .setClaims(claims)
                 .compact();
     }
 

--- a/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
@@ -4,7 +4,11 @@ import com.umbrella.domain.WhenToMeet.Event;
 import com.umbrella.domain.WhenToMeet.EventRepository;
 import com.umbrella.domain.WhenToMeet.Schedule;
 import com.umbrella.domain.WhenToMeet.ScheduleRepository;
+import com.umbrella.domain.WorkSpace.WorkSpace;
+import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
+import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import com.umbrella.domain.exception.WhenToMeetException;
+import com.umbrella.domain.exception.WorkspaceException;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
 import com.umbrella.dto.whenToMeet.RequestScheduleDto;
 import com.umbrella.security.utils.SecurityUtil;
@@ -12,7 +16,6 @@ import com.umbrella.service.WhenToMeetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import java.time.Instant;
 import java.time.LocalTime;
@@ -20,12 +23,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static com.umbrella.domain.exception.WhenToMeetExceptionType.*;
+import static com.umbrella.domain.exception.WorkspaceExceptionType.NOT_FOUNT_WORKSPACE;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class WhenToMeetServiceImpl implements WhenToMeetService {
 
+    private final WorkSpaceRepository workSpaceRepository;
     private final EventRepository eventRepository;
     private final ScheduleRepository scheduleRepository;
     private final SecurityUtil securityUtil;
@@ -51,33 +56,40 @@ public class WhenToMeetServiceImpl implements WhenToMeetService {
 
     @Override
     public Event createEvent(RequestEventDto requestEventDto) {
-        try {
-            Instant nowInstant = (new Date()).toInstant().truncatedTo(ChronoUnit.DAYS);
-            Instant startInstant = requestEventDto.getStartDate().toInstant().truncatedTo(ChronoUnit.DAYS);
-            Instant endInstant = requestEventDto.getEndDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+        Optional<WorkSpace> optionalWorkspace  = workSpaceRepository.findById(requestEventDto.getWorkspaceId());
+        if (optionalWorkspace.isEmpty()) {
+            throw new WorkspaceException(NOT_FOUNT_WORKSPACE);
+        }
+        WorkSpace theWorkspace = optionalWorkspace.get();
 
-            if ((!startInstant.equals(nowInstant) && !startInstant.isAfter(nowInstant)) || !endInstant.isAfter(startInstant)) {
-                throw new WhenToMeetException(ILLEGAL_DATE_RANGE_ERROR);
-            }
+        Instant nowInstant = (new Date()).toInstant().truncatedTo(ChronoUnit.DAYS);
+        Instant startInstant = requestEventDto.getStartDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+        Instant endInstant = requestEventDto.getEndDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+
+        if ((!startInstant.equals(nowInstant) && !startInstant.isAfter(nowInstant)) || !endInstant.isAfter(startInstant)) {
+            throw new WhenToMeetException(ILLEGAL_DATE_RANGE_ERROR);
+        }
+        try {
 
             Event newEvent = eventRepository.save(
                     Event.builder()
+                            .workSpace(theWorkspace)
                             .title(requestEventDto.getTitle())
                             .startDate(Date.from(startInstant))
                             .endDate(Date.from(endInstant))
-                            .members(requestEventDto.getMembers())
                             .build()
             );
             return newEvent;
         } catch (Exception e) {
+            e.printStackTrace();
             throw new WhenToMeetException(DEFAULT_WHEN2MEET_ERROR);
         }
     }
 
     @Override
     public String deleteEvent(UUID uuid) {
-        String loginUserName = securityUtil.getLoginUserNickname();
-        Event theEvent = validateEvent(uuid, loginUserName);
+        Long loginUserId = securityUtil.getLoginUserId();
+        Event theEvent = validateEvent(uuid, loginUserId);
         eventRepository.delete(theEvent);
 
         return theEvent.getUuid().toString();
@@ -85,28 +97,44 @@ public class WhenToMeetServiceImpl implements WhenToMeetService {
 
     @Override
     public Schedule addSchedule(UUID uuid, RequestScheduleDto requestScheduleDto) {
-        String scheduleMember = securityUtil.getLoginUserNickname();
-        Event theEvent = validateEvent(uuid, scheduleMember);
+        Long loginUserId = securityUtil.getLoginUserId();
+        Event theEvent = validateEvent(uuid, loginUserId);
+
+        return generateSchedule(requestScheduleDto, loginUserId, theEvent);
+    }
+
+    @Override
+    public Schedule modifySchedule(UUID uuid, RequestScheduleDto requestScheduleDto) {
+        Long loginUserId = securityUtil.getLoginUserId();
+        Event theEvent = validateEvent(uuid, loginUserId);
+        scheduleRepository.deleteByEventAndUserId(theEvent, loginUserId);
+
+        return generateSchedule(requestScheduleDto, loginUserId, theEvent);
+    }
+
+    private Schedule generateSchedule(RequestScheduleDto requestScheduleDto, Long loginUserId, Event theEvent) {
         Instant scheduleDate = requestScheduleDto.getDate().toInstant().truncatedTo(ChronoUnit.DAYS);
 
-        Schedule savedSchedule = scheduleRepository.save(Schedule.builder()
-                .member(scheduleMember)
+        return scheduleRepository.save(Schedule.builder()
                 .event(theEvent)
+                .userId(loginUserId)
                 .date(Date.from(scheduleDate))
                 .timeBlocks(requestScheduleDto.getTimeBlocks())
                 .build());
-
-        return savedSchedule;
     }
 
-    private Event validateEvent(UUID uuid, String userNickName) {
+    private Event validateEvent(UUID uuid, Long loginUserId) {
         Optional<Event> optionalEvent = eventRepository.findEventByUuid(uuid);
         if (optionalEvent.isEmpty()) {
             throw new WhenToMeetException(NOT_FOUND_EVENT_ERROR);
         }
-        if (!optionalEvent.get().getMembers().contains(userNickName)) {
+        Event theEvent = optionalEvent.get();
+        if (theEvent.getWorkSpace().getWorkspaceUsers().stream().anyMatch(workspaceUser -> {
+            return !(workspaceUser.getWorkspaceUser().getId() == (loginUserId));
+        })) {
             throw new WhenToMeetException(NOT_FOUND_EVENT_ERROR);
         }
-        return optionalEvent.get();
+
+        return theEvent;
     }
 }

--- a/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
@@ -1,0 +1,91 @@
+package com.umbrella.service.Impl;
+
+import com.umbrella.domain.WhenToMeet.Event;
+import com.umbrella.domain.WhenToMeet.EventRepository;
+import com.umbrella.domain.WhenToMeet.Schedule;
+import com.umbrella.domain.WhenToMeet.ScheduleRepository;
+import com.umbrella.domain.exception.WhenToMeetException;
+import com.umbrella.dto.whenToMeet.RequestEventDto;
+import com.umbrella.dto.whenToMeet.RequestScheduleDto;
+import com.umbrella.security.utils.SecurityUtil;
+import com.umbrella.service.WhenToMeetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static com.umbrella.domain.exception.WhenToMeetExceptionType.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class WhenToMeetServiceImpl implements WhenToMeetService {
+
+    private final EventRepository eventRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final SecurityUtil securityUtil;
+
+    @Override
+    public Event createEvent(RequestEventDto requestEventDto) {
+        try {
+            Instant nowInstant = (new Date()).toInstant().truncatedTo(ChronoUnit.DAYS);
+            Instant startInstant = requestEventDto.getStartDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+            Instant endInstant = requestEventDto.getEndDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+
+            if ((!startInstant.equals(nowInstant) && !startInstant.isAfter(nowInstant)) || !endInstant.isAfter(startInstant)) {
+                throw new WhenToMeetException(ILLEGAL_DATE_RANGE_ERROR);
+            }
+
+            Event newEvent = eventRepository.save(
+                    Event.builder()
+                            .title(requestEventDto.getTitle())
+                            .startDate(Date.from(startInstant))
+                            .endDate(Date.from(endInstant))
+                            .members(requestEventDto.getMembers())
+                            .build()
+            );
+            return newEvent;
+        } catch (Exception e) {
+            throw new WhenToMeetException(DEFAULT_WHEN2MEET_ERROR);
+        }
+    }
+
+    @Override
+    public String deleteEvent(UUID uuid) {
+        Optional<Event> optionalEvent = validateEvent(uuid);
+        eventRepository.delete(optionalEvent.get());
+
+        return optionalEvent.get().getUuid().toString();
+    }
+
+    @Override
+    public Schedule addSchedule(UUID uuid, RequestScheduleDto requestScheduleDto) {
+        String scheduleMember = securityUtil.getLoginUserNickname();
+        Optional<Event> optionalEvent = validateEvent(uuid);
+        Instant scheduleDate = requestScheduleDto.getDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+
+        Schedule savedSchedule = scheduleRepository.save(Schedule.builder()
+                .member(scheduleMember)
+                .event(optionalEvent.get())
+                .date(Date.from(scheduleDate))
+                .timeBlocks(requestScheduleDto.getTimeBlocks())
+                .build());
+
+        return savedSchedule;
+    }
+
+    private Optional<Event> validateEvent(UUID uuid) {
+        Optional<Event> optionalEvent = eventRepository.findEventByUuid(uuid);
+        if (optionalEvent.isEmpty()) {
+            throw new WhenToMeetException(NOT_FOUND_EVENT_ERROR);
+        }
+        if (!optionalEvent.get().getMembers().contains(securityUtil.getLoginUserNickname())) {
+            throw new WhenToMeetException(NOT_FOUND_EVENT_ERROR);
+        }
+        return optionalEvent;
+    }
+}

--- a/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/WhenToMeetServiceImpl.java
@@ -6,7 +6,6 @@ import com.umbrella.domain.WhenToMeet.Schedule;
 import com.umbrella.domain.WhenToMeet.ScheduleRepository;
 import com.umbrella.domain.WorkSpace.WorkSpace;
 import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
 import com.umbrella.domain.exception.WhenToMeetException;
 import com.umbrella.domain.exception.WorkspaceException;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
@@ -70,7 +69,6 @@ public class WhenToMeetServiceImpl implements WhenToMeetService {
             throw new WhenToMeetException(ILLEGAL_DATE_RANGE_ERROR);
         }
         try {
-
             Event newEvent = eventRepository.save(
                     Event.builder()
                             .workSpace(theWorkspace)
@@ -79,6 +77,7 @@ public class WhenToMeetServiceImpl implements WhenToMeetService {
                             .endDate(Date.from(endInstant))
                             .build()
             );
+
             return newEvent;
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/umbrella/service/Impl/WorkSpaceServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/WorkSpaceServiceImpl.java
@@ -4,8 +4,6 @@ import com.umbrella.domain.User.User;
 import com.umbrella.domain.User.UserRepository;
 import com.umbrella.domain.WorkSpace.WorkSpace;
 import com.umbrella.domain.WorkSpace.WorkSpaceRepository;
-import com.umbrella.domain.WorkSpace.WorkspaceUser;
-import com.umbrella.domain.WorkSpace.WorkspaceUserRepository;
 import com.umbrella.domain.exception.UserException;
 import com.umbrella.domain.exception.UserExceptionType;
 import com.umbrella.domain.exception.WorkspaceException;
@@ -27,7 +25,6 @@ import java.util.stream.Collectors;
 public class WorkSpaceServiceImpl implements WorkSpaceService {
     private final WorkSpaceRepository workSpaceRepository;
     private final SecurityUtil securityUtil;
-    private final WorkspaceUserRepository workspaceUserRepository;
     private final UserRepository userRepository;
 
     public Long save(WorkspaceRequestDto requestDto){

--- a/src/main/java/com/umbrella/service/JwtService.java
+++ b/src/main/java/com/umbrella/service/JwtService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface JwtService {
 
-    String createAccessToken(String email);
+    String createAccessToken(String email, String nickName);
     String createRefreshToken(String email);
 
     void updateRefreshToken(String email, String refreshToken);
@@ -26,6 +26,8 @@ public interface JwtService {
     Optional<String> extractRefreshToken(HttpServletRequest request) throws IOException, ServletException;
 
     Optional<String> extractEmail(String accessToken);
+
+    Optional<String> extractNickName(String accessToken);
 
     Optional<String> extractSubject(String accessToken);
 

--- a/src/main/java/com/umbrella/service/WhenToMeetService.java
+++ b/src/main/java/com/umbrella/service/WhenToMeetService.java
@@ -1,0 +1,17 @@
+package com.umbrella.service;
+
+import com.umbrella.domain.WhenToMeet.Event;
+import com.umbrella.domain.WhenToMeet.Schedule;
+import com.umbrella.dto.whenToMeet.RequestEventDto;
+import com.umbrella.dto.whenToMeet.RequestScheduleDto;
+
+import java.util.UUID;
+
+public interface WhenToMeetService {
+
+    Event createEvent(RequestEventDto requestEventDto);
+
+    String deleteEvent(UUID uuid);
+
+    Schedule addSchedule(UUID uuid, RequestScheduleDto requestScheduleDto);
+}

--- a/src/main/java/com/umbrella/service/WhenToMeetService.java
+++ b/src/main/java/com/umbrella/service/WhenToMeetService.java
@@ -19,4 +19,6 @@ public interface WhenToMeetService {
     String deleteEvent(UUID uuid);
 
     Schedule addSchedule(UUID uuid, RequestScheduleDto requestScheduleDto);
+
+    Schedule modifySchedule(UUID uuid, RequestScheduleDto requestScheduleDto);
 }

--- a/src/main/java/com/umbrella/service/WhenToMeetService.java
+++ b/src/main/java/com/umbrella/service/WhenToMeetService.java
@@ -5,9 +5,14 @@ import com.umbrella.domain.WhenToMeet.Schedule;
 import com.umbrella.dto.whenToMeet.RequestEventDto;
 import com.umbrella.dto.whenToMeet.RequestScheduleDto;
 
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface WhenToMeetService {
+
+    Map<String, Map<LocalTime, Integer>> getScheduleInEvent(List<Schedule> schedules);
 
     Event createEvent(RequestEventDto requestEventDto);
 

--- a/src/test/java/com/umbrella/project_umbrella/jwt/JwtAuthenticationProcessingFilterTest.java
+++ b/src/test/java/com/umbrella/project_umbrella/jwt/JwtAuthenticationProcessingFilterTest.java
@@ -109,8 +109,10 @@ public class JwtAuthenticationProcessingFilterTest {
                 .andReturn();
 
         String accessToken = result.getResponse().getHeader(accessHeader);
-//        String refreshToken = result.getResponse().getHeader(refreshHeader); // Json Body 에 RefreshToken 을 전송했을 때
         String refreshToken = result.getResponse().getCookie(COOKIE_REFRESH_TOKEN_KEY).getValue();
+
+        System.out.println(accessToken);
+        System.out.println(refreshToken);
 
         Map<String, String> tokenMap = new HashMap<>();
         tokenMap.put(accessHeader,accessToken);

--- a/src/test/java/com/umbrella/project_umbrella/jwt/JwtServiceTest.java
+++ b/src/test/java/com/umbrella/project_umbrella/jwt/JwtServiceTest.java
@@ -52,6 +52,7 @@ public class JwtServiceTest {
     private static final String BEARER = "Bearer ";
 
     private String email = "test@test.com";
+    private String nickName = "테스트계정";
     private String password = "12345";
     @BeforeEach
     public void init() {
@@ -59,7 +60,7 @@ public class JwtServiceTest {
                         .email(email)
                         .password(password)
                         .name("홍길동")
-                        .nickName("테스트계정")
+                        .nickName(nickName)
                         .age(22)
                         .gender(Gender.MALE)
                         .role(Role.USER)
@@ -75,7 +76,7 @@ public class JwtServiceTest {
     @DisplayName("[SUCCESS]_엑세스_토큰_발급")
     public void createAccessTokenTest() {
         // given
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
 
         // when
         String findEmail = jwtService.extractEmail(accessToken).orElseThrow(
@@ -162,7 +163,7 @@ public class JwtServiceTest {
         // given
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
 
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         jwtService.setAccessTokenHeader(mockHttpServletResponse, accessToken);
@@ -184,7 +185,7 @@ public class JwtServiceTest {
         // given
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
 
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
 //        jwtService.setRefreshTokenHeader(mockHttpServletResponse, refreshToken);  // RefreshToken In Json Body
@@ -208,7 +209,7 @@ public class JwtServiceTest {
         // given
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
 
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         // when
@@ -248,7 +249,7 @@ public class JwtServiceTest {
     @DisplayName("[SUCCESS]_엑세스_토큰_추출")
     public void extractAccessTokenTest() throws IOException, ServletException {
         // given
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);
@@ -272,7 +273,7 @@ public class JwtServiceTest {
     @Disabled
     public void extractRefreshTokenTest() throws IOException, ServletException {
         // given
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);
@@ -289,7 +290,7 @@ public class JwtServiceTest {
     @DisplayName("[SUCCESS]_엑세스_토큰_클레임_추출")
     public void extractAccessTokenClaimsTest() throws IOException, ServletException {
         // given
-        String accessToken = jwtService.createAccessToken(email);
+        String accessToken = jwtService.createAccessToken(email, nickName);
         String refreshToken = jwtService.createRefreshToken(email);
 
         HttpServletRequest httpServletRequest = setRequest(accessToken, refreshToken);


### PR DESCRIPTION
WhenToMeetController, WhenToMeetService 및 연관 DTO 추가
WhenToMeetException 추가 

Event 로 일정이 발생한 일자를 지정하고, 각 일자에 맞는 사용자의 일정을 Schedule 엔티티가 저장받고 사용자가 지정한 시간은 Schedule 의 TimeBlock 에 각각 저장된다. 2차원 배열을 이용하는 방법보다는 조금 더 알아보기 쉽고 확장성이 있는 것 같아 이 방법을 사용하게 됨

JWT 의 확장성 즉, 추후 SecurityContextHolder 에 DB 를 거치지 않고 AccessToken 을 파싱하는 것만으로도 주요정보를 제외한 유저 정보를 저장할 수 있도록 NickName 을 AccessToken Claim 으로 추가하였고 그로 인한 수정 사항이 발생

When2Meet Event GET 요청 시, 각 날짜의 timeBlock 과 집계를 반환하도록 변경  

기존에는 String 을 통해 사용자의 이름을 받았지만, Event 엔티티에 workspace_id 를 @JoinColumn 으로 설정했다. Workspace 와 연관관계를 설정하는 것으로 해당 워크스페이스에 참여하는 인원을 동적을 받을 수 있게 되었다. 또한 Schedule 엔티티에 해당 유저 정보를 연관 짓기 위해 기존에는 String 으로 닉네임을 정적으로 설정했지만, 변경 가능성이 존재하기 때문에 변경 가능성이 극히 드문 Long 타입의 userId 로 변경했다

추가적으로 Schedule 수정 기능을 추가했는데, 기존 Schedule 을 삭제하고 새롭게 등록된 Schedule 을 추가하는 것으로 설정했다.

Workspace Entity 도 Event 와 1:N 관계를 맺도록 한 후, WorkspaceResponseDto 에 List<Event> events 필드를 넣어 해당  Workspace 에 만들어진 Event 에 대한 정보도 같이 응답 값으로 보내려고 하였으나, 무한참조가 발생하였다.

무한참조를 끊기 위해 Event 객체를 직접 WorkspaceResponseDto 에 넣는 것이 아닌, eventId 와 title 을 각각 필드로 갖는 EventResponseDto 객체를 생성하여 해당 값을 응답 값으로 전송하는 것으로 무한참조를 해소했다. 