### PR TITLE
[FEAT] : add PostImgService

### DIFF
--- a/src/main/java/com/umbrella/domain/PostImg/PostImg.java
+++ b/src/main/java/com/umbrella/domain/PostImg/PostImg.java
@@ -1,6 +1,8 @@
 package com.umbrella.domain.PostImg;
 
+import com.umbrella.domain.Board.Board;
 import com.umbrella.domain.Post.Post;
+import com.umbrella.domain.WorkSpace.WorkSpace;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,9 +22,6 @@ public class PostImg {
     private Long id;
 
     @Column(nullable = false)
-    private String imgUrl;
-
-    @Column(nullable = false)
     private String imgName;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -30,10 +29,22 @@ public class PostImg {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workspace_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private WorkSpace workSpace;
+
+
     @Builder
-    public PostImg(String imgUrl,String imgName, Post post) {
-        this.imgUrl = imgUrl;
-        this.imgName = imgName;
+    public PostImg(String imgName, Post post, Board board, WorkSpace workSpace) {
+        this.workSpace = workSpace;
+        this.board = board;
         this.post = post;
+        this.imgName = imgName;
     }
 }

--- a/src/main/java/com/umbrella/domain/PostImg/PostImgRepository.java
+++ b/src/main/java/com/umbrella/domain/PostImg/PostImgRepository.java
@@ -1,0 +1,33 @@
+package com.umbrella.domain.PostImg;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+
+public interface PostImgRepository extends JpaRepository<PostImg, Long> {
+
+    List<PostImg> findAllByPost_Id(Long postId);
+
+    List<PostImg> findAllByBoard_Id(Long boardId);
+
+    List<PostImg> findAllByWorkSpaceId(Long workspaceId);
+
+    void deleteByImgName (String imageName);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true) // @Modifying 권장 옵션
+    @Query(value = "DELETE FROM PostImg pi WHERE pi.post.id =: postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "DELETE FROM PostImg pi WHERE pi.board.id =: boardId")
+    void deleteAllByBoardId(@Param("boardId") Long boardId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "DELETE FROM PostImg pi WHERE pi.workSpace.id =: workSpaceId")
+    void deleteAllByWorkSpaceId(@Param("workSpaceId") Long workSpaceId);
+
+}

--- a/src/main/java/com/umbrella/dto/post/PostSaveRequestDto.java
+++ b/src/main/java/com/umbrella/dto/post/PostSaveRequestDto.java
@@ -4,9 +4,12 @@ import com.umbrella.domain.Post.Post;
 import com.umbrella.domain.User.User;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 public class PostSaveRequestDto {
@@ -15,6 +18,9 @@ public class PostSaveRequestDto {
     @NotBlank
     @Size(min = 30, max = 1000)
     private String content;
+
+    @Nullable
+    private List<String> fileNameList;
 
     @Builder
     public PostSaveRequestDto(String title, String content,String writer , String boardName){
@@ -28,5 +34,6 @@ public class PostSaveRequestDto {
                 content(content).
                 build();
     }
+
 
 }

--- a/src/main/java/com/umbrella/dto/post/PostUpdateRequestDto.java
+++ b/src/main/java/com/umbrella/dto/post/PostUpdateRequestDto.java
@@ -2,9 +2,11 @@ package com.umbrella.dto.post;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 @Getter
 public class PostUpdateRequestDto {
@@ -16,6 +18,16 @@ public class PostUpdateRequestDto {
     @NotBlank
     @Size(min =30, max = 1000)
     private String content;
+
+
+    // 새롭게 추가된 이미지
+    @Nullable
+    private List<String> addedFileNameList;
+
+    // 삭제된 이미지
+    @Nullable
+    private List<String> deletedFileNameList;
+
 
     @Builder
     public PostUpdateRequestDto(String title, String content){

--- a/src/main/java/com/umbrella/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/BoardServiceImpl.java
@@ -33,6 +33,7 @@ public class BoardServiceImpl implements BoardService {
     private final SecurityUtil securityUtil;
     private final WorkspaceUserRepository workspaceUserRepository;
     private final UserRepository userRepository;
+    private final PostImgServiceImpl postImgService;
 
     @Override
     public Long save(Long workspace_id, BoardSaveRequestDto requestDto) {
@@ -54,6 +55,7 @@ public class BoardServiceImpl implements BoardService {
         validateUser();
         Board board = validateBoard(id);
         boardRepository.delete(board);
+        postImgService.postImgDeletedByBoardId(id);
         return id;
     }
 

--- a/src/main/java/com/umbrella/service/Impl/FileUploadService.java
+++ b/src/main/java/com/umbrella/service/Impl/FileUploadService.java
@@ -142,4 +142,18 @@ public class FileUploadService {
     }
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/com/umbrella/service/Impl/PostImgServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/PostImgServiceImpl.java
@@ -1,0 +1,125 @@
+package com.umbrella.service.Impl;
+
+import com.umbrella.domain.Post.Post;
+import com.umbrella.domain.PostImg.PostImg;
+import com.umbrella.domain.PostImg.PostImgRepository;
+import com.umbrella.dto.post.PostSaveRequestDto;
+import com.umbrella.dto.post.PostUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostImgServiceImpl {
+
+    private final PostImgRepository postImgRepository;
+    private final AwsS3UploadServiceImpl awsS3UploadService;
+
+    public void createPostImg(PostSaveRequestDto requestDto, Post post){
+
+        List<PostImg> postImgList = new ArrayList<>();
+
+        if(requestDto.getFileNameList() != null) {
+
+            for(String fileName : requestDto.getFileNameList()){
+                PostImg postImg = PostImg.builder()
+                        .post(post) // 연결관계 생성
+                        .board(post.getBoard())
+                        .workSpace(post.getBoard().getWorkSpace())
+                        .imgName(fileName)
+                        .build();
+
+                postImgList.add(postImg);
+            }
+
+        }
+
+        postImgRepository.saveAll(postImgList);
+    }
+
+
+    // 새롭게 추가되는 이미지 -> DB에 저장
+    // 새롭게 삭제되는 이미지 -> DB에 삭제
+    public void updatePostImg(Post post, PostUpdateRequestDto requestDto){
+
+        List<PostImg> postImgList = new ArrayList<>();
+
+        // 새로운 이미지 추가
+        if(requestDto.getAddedFileNameList() != null){
+            for(String fileName : requestDto.getAddedFileNameList()){
+                PostImg postImg = PostImg.builder()
+                        .post(post) // 연결관계 생성
+                        .board(post.getBoard())
+                        .workSpace(post.getBoard().getWorkSpace())
+                        .imgName(fileName)
+                        .build();
+
+                postImgList.add(postImg);
+            }
+            postImgRepository.saveAll(postImgList);
+        }
+
+        // 삭제되는 이미지
+        if(requestDto.getDeletedFileNameList() != null){
+
+            for(String fileName : requestDto.getDeletedFileNameList()){
+                postImgRepository.deleteByImgName(fileName);
+            }
+
+        }
+
+    }
+
+
+    // 1. PostId로 postImg 엔터티들 갖고오기
+    // 2. for문 돌아가면서 AwsS3에 삭제 요청 날리기
+    // 3. DB에 삭제 쿼리 날리기
+    public void postImgDeletedByPostId(Long postId){
+        List<PostImg> postImgList = postImgRepository.findAllByPost_Id(postId);
+
+        for(PostImg postImg : postImgList){
+            awsS3UploadService.deleteFile(postImg.getImgName());
+            awsS3UploadService.deleteFile(postImg.getImgName()
+                    .replace("post/","post-resized/"));
+        }
+
+        postImgRepository.deleteAllByPostId(postId);
+    }
+
+    // 1. boardId 로 postImg 엔터티들 갖고오기
+    // 2. for문 돌아가면서 AwsS3에 삭제 요청 날리기
+    // 3. DB에 벌크성 삭제 쿼리 날리기
+    public void postImgDeletedByBoardId(Long boardId){
+        List<PostImg> postImgList = postImgRepository.findAllByBoard_Id(boardId);
+
+        for(PostImg postImg : postImgList){
+            awsS3UploadService.deleteFile(postImg.getImgName());
+            awsS3UploadService.deleteFile(postImg.getImgName()
+                    .replace("post/","post-resized/"));
+        }
+
+        postImgRepository.deleteAllByBoardId(boardId);
+    }
+
+    // 1. boardId 로 postImg 엔터티들 갖고오기
+    // 2. for문 돌아가면서 AwsS3에 삭제 요청 날리기
+    // 3. DB에 벌크성 삭제 쿼리 날리기
+    public void postImgDeletedByWorkspaceId(Long workspaceId){
+
+        List<PostImg> postImgList = postImgRepository.findAllByWorkSpaceId(workspaceId);
+
+        for(PostImg postImg : postImgList){
+            awsS3UploadService.deleteFile(postImg.getImgName());
+            awsS3UploadService.deleteFile(postImg.getImgName()
+                    .replace("post/","post-resized/"));
+        }
+        postImgRepository.deleteAllByWorkSpaceId(workspaceId);
+    }
+
+
+}

--- a/src/main/java/com/umbrella/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/umbrella/service/Impl/PostServiceImpl.java
@@ -29,10 +29,11 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
-    private final CommentRepository commentRepository;
     private final PostHeartRepository postHeartRepository;
     private final SecurityUtil securityUtil;
 
+    // postImgService add
+    private final PostImgServiceImpl postImgService;
 
 
     // 저장 메서드
@@ -49,7 +50,11 @@ public class PostServiceImpl implements PostService {
                 .board(board)
                 .build();
 
-        return postRepository.save(post).getId();
+        Post savedPost = postRepository.save(post);
+
+        postImgService.createPostImg(requestDto, post);
+
+        return savedPost.getId();
     }
 
 
@@ -59,6 +64,8 @@ public class PostServiceImpl implements PostService {
         Post post = validatePost(post_id);
         validateUser(post.getUser());
         post.update(requestDto.getTitle(), requestDto.getContent());
+
+        postImgService.updatePostImg(post, requestDto);
 
         return post_id;
     }
@@ -70,6 +77,7 @@ public class PostServiceImpl implements PostService {
         validateUser(post.getUser());
         postRepository.delete(post);
         postHeartRepository.delete(postHeartRepository.findByUserAndPost(post.getUser(),post));
+        postImgService.postImgDeletedByPostId(post_id);
         return post_id;
     }
 


### PR DESCRIPTION
## Summary
* Post가 생성되었을 때 Dto로 FileNameList를 받아 PostService에서 PostImgService를 생성해서 처리 
![image](https://github.com/rlaxoehd4234/Umbrella/assets/80961461/0cd79c6e-3793-4661-b1f2-b74cbb8bbc87)
* JPA saveAll 메소드 사용

* 게시물이 업데이트 하는 경우에 이미지도 업데이트 될 수 있어서 @Nullable 옵션을 사용해서 관련 Dto에 추가 
![image](https://github.com/rlaxoehd4234/Umbrella/assets/80961461/ce6ee6cf-401a-4a01-a20c-49f779a82e41)
* 워크스페이스, 게시판이 삭제되는 경우 관련 엔터티들이 삭제됨   

## DevDetails
* 관련 이미지들이 삭제되는 경우, @Query, @Modifying 옵션을 사용해서 Delete 쿼리들이 여러번 나가는 것을 방지
* @Modyfying 권장 옵션 추가 
![image](https://github.com/rlaxoehd4234/Umbrella/assets/80961461/180cb1eb-b176-4a8c-8e29-aad54bfc29fb)


## ChangeLogic
